### PR TITLE
feat: 新增 inIfNotNull/notInIfNotNull 条件运算符

### DIFF
--- a/nextentity-core/pom.xml
+++ b/nextentity-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.flow-entity</groupId>
         <artifactId>nextentity</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4</version>
     </parent>
 
     <artifactId>nextentity-core</artifactId>

--- a/nextentity-core/src/main/java/io/github/nextentity/api/ExpressionBuilder.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/api/ExpressionBuilder.java
@@ -152,6 +152,31 @@ public interface ExpressionBuilder<T, U, B> {
     /// @return 构建器实例
     B notIn(@NonNull Collection<? extends U> values);
 
+    /// 如果集合不为 null，则在指定值集合中。
+    ///
+    /// 适用于可选列表参数的场景：
+    /// ```java
+    /// public List<User> search(List<Long> ids) {
+    ///     return repository.query()
+    ///         .where(User::getId).inIfNotNull(ids)
+    ///         .list();
+    /// }
+    /// ```
+    ///
+    /// 注意：集合为 null 时条件跳过，空集合（size=0）时生成 `WHERE 1=0`。
+    ///
+    /// @param values 值集合，可为 null
+    /// @return 构建器实例
+    B inIfNotNull(Collection<? extends U> values);
+
+    /// 如果集合不为 null，则不在指定值集合中。
+    ///
+    /// 注意：集合为 null 时条件跳过，空集合（size=0）时生成 `WHERE 1=1`。
+    ///
+    /// @param values 值集合，可为 null
+    /// @return 构建器实例
+    B notInIfNotNull(Collection<? extends U> values);
+
     /// 值为 null。
     ///
     /// @return 构建器实例

--- a/nextentity-core/src/main/java/io/github/nextentity/api/SimpleExpression.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/api/SimpleExpression.java
@@ -139,6 +139,26 @@ public interface SimpleExpression<T, U> extends Expression<T, U> {
     /// @return 断言对象
     Predicate<T> notIn(@NonNull Collection<? extends U> values);
 
+    /// 如果集合不为 null，则在指定集合中。
+    ///
+    /// 注意：集合为 null 时条件跳过，空集合（size=0）时生成 `WHERE 1=0`。
+    ///
+    /// @param values 值集合，可为 null
+    /// @return 断言对象
+    default Predicate<T> inIfNotNull(Collection<? extends U> values) {
+        return values == null ? Predicate.ofTrue() : in(values);
+    }
+
+    /// 如果集合不为 null，则不在指定集合中。
+    ///
+    /// 注意：集合为 null 时条件跳过，空集合（size=0）时生成 `WHERE 1=1`。
+    ///
+    /// @param values 值集合，可为 null
+    /// @return 断言对象
+    default Predicate<T> notInIfNotNull(Collection<? extends U> values) {
+        return values == null ? Predicate.ofTrue() : notIn(values);
+    }
+
     /// 值为 null。
     ///
     /// @return 断言对象

--- a/nextentity-core/src/main/java/io/github/nextentity/core/expression/AbstractExpressionBuilder.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/expression/AbstractExpressionBuilder.java
@@ -150,6 +150,22 @@ public abstract class AbstractExpressionBuilder<T, U, B> implements ExpressionTr
         return next(operate(Operator.IN, nodes).operate(Operator.NOT));
     }
 
+    /// 检查值是否在指定集合中（如果集合不为 null）。
+    ///
+    /// @param values 值集合，可为 null
+    /// @return 表达式构建器实例
+    public B inIfNotNull(Collection<? extends U> values) {
+        return values == null ? operateNull() : in(values);
+    }
+
+    /// 检查值是否不在指定集合中（如果集合不为 null）。
+    ///
+    /// @param values 值集合，可为 null
+    /// @return 表达式构建器实例
+    public B notInIfNotNull(Collection<? extends U> values) {
+        return values == null ? operateNull() : notIn(values);
+    }
+
     /// 检查值是否为空。
     ///
     /// @return 表达式构建器实例

--- a/nextentity-core/src/test/java/io/github/nextentity/core/expression/AbstractExpressionBuilderTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/core/expression/AbstractExpressionBuilderTest.java
@@ -8,15 +8,14 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-///
- /// 单元测试 AbstractExpressionBuilder.
+/// 单元测试 AbstractExpressionBuilder.
 class AbstractExpressionBuilderTest {
 
+    private PathNode rootNode;
     private TestExpressionBuilder builder;
-    private ExpressionNode capturedNode;
 
-///
-     /// Concrete implementation for testing.
+    /// Concrete implementation for testing.
+    /// 返回新构建器，保存操作后的 root 节点。
     private class TestExpressionBuilder extends AbstractExpressionBuilder<String, Object, TestExpressionBuilder> {
 
         public TestExpressionBuilder(ExpressionNode root) {
@@ -25,198 +24,122 @@ class AbstractExpressionBuilderTest {
 
         @Override
         protected TestExpressionBuilder next(ExpressionNode operate) {
-            capturedNode = operate;
-            return this;
+            return new TestExpressionBuilder(operate);
         }
     }
 
     @BeforeEach
     void setUp() {
-        PathNode rootNode = new PathNode("test");
+        rootNode = new PathNode("test");
         builder = new TestExpressionBuilder(rootNode);
-        capturedNode = null;
     }
 
     @Nested
     class GetRoot {
 
-///
-         /// 测试目标: 验证y getRoot() returns the root node.
-         /// 测试场景: Call getRoot() after construction.
-         /// 预期结果: Returns the root node passed to constructor.
         @Test
         void getRoot_ShouldReturnConstructorValue() {
-            // when
-            ExpressionNode result = builder.getRoot();
-
-            // then
-            assertThat(result).isInstanceOf(PathNode.class);
+            assertThat(builder.getRoot()).isEqualTo(rootNode);
         }
     }
 
     @Nested
     class EqualityOperators {
 
-///
-         /// 测试目标: 验证y eq() creates EQ operator node.
-         /// 测试场景: Call eq() with a value.
-         /// 预期结果: 创建 operator node with EQ operator.
         @Test
         void eq_ShouldCreateEqOperator() {
-            // when
-            builder.eq("value");
+            TestExpressionBuilder result = builder.eq("value");
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.EQ);
         }
 
-///
-         /// 测试目标: 验证y eqIfNotNull() with null returns EmptyNode.
-         /// 测试场景: Call eqIfNotNull() with null value.
-         /// 预期结果: Returns EmptyNode.
         @Test
         void eqIfNotNull_WhenNull_ShouldReturnEmptyNode() {
-            // when
-            builder.eqIfNotNull(null);
+            TestExpressionBuilder result = builder.eqIfNotNull(null);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(EmptyNode.class);
+            assertThat(result.getRoot()).isInstanceOf(EmptyNode.class);
         }
 
-///
-         /// 测试目标: 验证y eqIfNotNull() with value creates EQ operator.
-         /// 测试场景: Call eqIfNotNull() with non-null value.
-         /// 预期结果: 创建 operator node with EQ operator.
         @Test
         void eqIfNotNull_WhenNotNull_ShouldCreateEqOperator() {
-            // when
-            builder.eqIfNotNull("value");
+            TestExpressionBuilder result = builder.eqIfNotNull("value");
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.EQ);
         }
 
-///
-         /// 测试目标: 验证y ne() creates NE operator node.
-         /// 测试场景: Call ne() with a value.
-         /// 预期结果: 创建 operator node with NE operator.
         @Test
         void ne_ShouldCreateNeOperator() {
-            // when
-            builder.ne("value");
+            TestExpressionBuilder result = builder.ne("value");
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.NE);
         }
 
-///
-         /// 测试目标: 验证y neIfNotNull() with null returns EmptyNode.
-         /// 测试场景: Call neIfNotNull() with null value.
-         /// 预期结果: Returns EmptyNode.
         @Test
         void neIfNotNull_WhenNull_ShouldReturnEmptyNode() {
-            // when
-            builder.neIfNotNull(null);
+            TestExpressionBuilder result = builder.neIfNotNull(null);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(EmptyNode.class);
+            assertThat(result.getRoot()).isInstanceOf(EmptyNode.class);
         }
     }
 
     @Nested
     class ComparisonOperators {
 
-///
-         /// 测试目标: 验证y gt() creates GT operator node.
-         /// 测试场景: Call gt() with a value.
-         /// 预期结果: 创建 operator node with GT operator.
         @Test
         void gt_ShouldCreateGtOperator() {
-            // when
-            builder.gt(10);
+            TestExpressionBuilder result = builder.gt(10);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.GT);
         }
 
-///
-         /// 测试目标: 验证y ge() creates GE operator node.
-         /// 测试场景: Call ge() with a value.
-         /// 预期结果: 创建 operator node with GE operator.
         @Test
         void ge_ShouldCreateGeOperator() {
-            // when
-            builder.ge(10);
+            TestExpressionBuilder result = builder.ge(10);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.GE);
         }
 
-///
-         /// 测试目标: 验证y lt() creates LT operator node.
-         /// 测试场景: Call lt() with a value.
-         /// 预期结果: 创建 operator node with LT operator.
         @Test
         void lt_ShouldCreateLtOperator() {
-            // when
-            builder.lt(10);
+            TestExpressionBuilder result = builder.lt(10);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.LT);
         }
 
-///
-         /// 测试目标: 验证y le() creates LE operator node.
-         /// 测试场景: Call le() with a value.
-         /// 预期结果: 创建 operator node with LE operator.
         @Test
         void le_ShouldCreateLeOperator() {
-            // when
-            builder.le(10);
+            TestExpressionBuilder result = builder.le(10);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.LE);
         }
 
-///
-         /// 测试目标: 验证y gtIfNotNull() with null returns EmptyNode.
-         /// 测试场景: Call gtIfNotNull() with null value.
-         /// 预期结果: Returns EmptyNode.
         @Test
         void gtIfNotNull_WhenNull_ShouldReturnEmptyNode() {
-            // when
-            builder.gtIfNotNull(null);
+            TestExpressionBuilder result = builder.gtIfNotNull(null);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(EmptyNode.class);
+            assertThat(result.getRoot()).isInstanceOf(EmptyNode.class);
         }
 
-///
-         /// 测试目标: 验证y geIfNotNull() with value creates GE operator.
-         /// 测试场景: Call geIfNotNull() with non-null value.
-         /// 预期结果: 创建 operator node with GE operator.
         @Test
         void geIfNotNull_WhenNotNull_ShouldCreateGeOperator() {
-            // when
-            builder.geIfNotNull(10);
+            TestExpressionBuilder result = builder.geIfNotNull(10);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.GE);
         }
     }
@@ -224,33 +147,21 @@ class AbstractExpressionBuilderTest {
     @Nested
     class NullOperators {
 
-///
-         /// 测试目标: 验证y isNull() creates IS_NULL operator node.
-         /// 测试场景: Call isNull().
-         /// 预期结果: 创建 operator node with IS_NULL operator.
         @Test
         void isNull_ShouldCreateIsNullOperator() {
-            // when
-            builder.isNull();
+            TestExpressionBuilder result = builder.isNull();
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.IS_NULL);
         }
 
-///
-         /// 测试目标: 验证y isNotNull() creates IS_NOT_NULL operator node.
-         /// 测试场景: Call isNotNull().
-         /// 预期结果: 创建 operator node with IS_NOT_NULL operator.
         @Test
         void isNotNull_ShouldCreateIsNotNullOperator() {
-            // when
-            builder.isNotNull();
+            TestExpressionBuilder result = builder.isNotNull();
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.IS_NOT_NULL);
         }
     }
@@ -258,49 +169,66 @@ class AbstractExpressionBuilderTest {
     @Nested
     class InOperators {
 
-///
-         /// 测试目标: 验证y in() with varargs creates IN operator node.
-         /// 测试场景: Call in() with multiple values.
-         /// 预期结果: 创建 operator node with IN operator.
         @Test
         void in_WithVarargs_ShouldCreateInOperator() {
-            // when
-            builder.in("a", "b", "c");
+            TestExpressionBuilder result = builder.in("a", "b", "c");
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.IN);
-            assertThat(opNode.operands()).hasSize(4); // root + 3 values
+            assertThat(opNode.operands()).hasSize(4);
         }
 
-///
-         /// 测试目标: 验证y in() with Collection creates IN operator node.
-         /// 测试场景: Call in() with a collection.
-         /// 预期结果: 创建 operator node with IN operator.
         @Test
         void in_WithCollection_ShouldCreateInOperator() {
-            // when
-            builder.in(List.of("a", "b"));
+            TestExpressionBuilder result = builder.in(List.of("a", "b"));
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.IN);
         }
 
-///
-         /// 测试目标: 验证y notIn() creates IN operator wrapped with NOT.
-         /// 测试场景: Call notIn() with values.
-         /// 预期结果: 创建 NOT(IN) operator structure.
         @Test
         void notIn_ShouldCreateNotInOperator() {
-            // when
-            builder.notIn("a", "b");
+            TestExpressionBuilder result = builder.notIn("a", "b");
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
+            assertThat(opNode.operator()).isEqualTo(Operator.NOT);
+            assertThat(opNode.operands().getFirst()).isInstanceOf(OperatorNode.class);
+            OperatorNode innerOp = (OperatorNode) opNode.operands().getFirst();
+            assertThat(innerOp.operator()).isEqualTo(Operator.IN);
+        }
+
+        @Test
+        void inIfNotNull_WhenNull_ShouldReturnEmptyNode() {
+            TestExpressionBuilder result = builder.inIfNotNull((List<String>) null);
+
+            assertThat(result.getRoot()).isInstanceOf(EmptyNode.class);
+        }
+
+        @Test
+        void inIfNotNull_WhenNonNull_ShouldCreateInOperator() {
+            TestExpressionBuilder result = builder.inIfNotNull(List.of("a", "b"));
+
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
+            assertThat(opNode.operator()).isEqualTo(Operator.IN);
+        }
+
+        @Test
+        void notInIfNotNull_WhenNull_ShouldReturnEmptyNode() {
+            TestExpressionBuilder result = builder.notInIfNotNull((List<String>) null);
+
+            assertThat(result.getRoot()).isInstanceOf(EmptyNode.class);
+        }
+
+        @Test
+        void notInIfNotNull_WhenNonNull_ShouldCreateNotInOperator() {
+            TestExpressionBuilder result = builder.notInIfNotNull(List.of("a", "b"));
+
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.NOT);
             assertThat(opNode.operands().getFirst()).isInstanceOf(OperatorNode.class);
             OperatorNode innerOp = (OperatorNode) opNode.operands().getFirst();
@@ -311,34 +239,22 @@ class AbstractExpressionBuilderTest {
     @Nested
     class BetweenOperators {
 
-///
-         /// 测试目标: 验证y between() creates BETWEEN operator node.
-         /// 测试场景: Call between() with two values.
-         /// 预期结果: 创建 operator node with BETWEEN operator.
         @Test
         void between_ShouldCreateBetweenOperator() {
-            // when
-            builder.between(1, 10);
+            TestExpressionBuilder result = builder.between(1, 10);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.BETWEEN);
-            assertThat(opNode.operands()).hasSize(3); // root + left + right
+            assertThat(opNode.operands()).hasSize(3);
         }
 
-///
-         /// 测试目标: 验证y notBetween() creates NOT(BETWEEN) structure.
-         /// 测试场景: Call notBetween() with two values.
-         /// 预期结果: 创建 NOT(BETWEEN) operator structure.
         @Test
         void notBetween_ShouldCreateNotBetweenOperator() {
-            // when
-            builder.notBetween(1, 10);
+            TestExpressionBuilder result = builder.notBetween(1, 10);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.NOT);
         }
     }
@@ -346,74 +262,44 @@ class AbstractExpressionBuilderTest {
     @Nested
     class LikeOperators {
 
-///
-         /// 测试目标: 验证y like() creates LIKE operator node.
-         /// 测试场景: Call like() with a pattern.
-         /// 预期结果: 创建 operator node with LIKE operator.
         @Test
         void like_ShouldCreateLikeOperator() {
-            // when
-            builder.like("%test%");
+            TestExpressionBuilder result = builder.like("%test%");
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.LIKE);
         }
 
-///
-         /// 测试目标: 验证y notLike() creates NOT(LIKE) structure.
-         /// 测试场景: Call notLike() with a pattern.
-         /// 预期结果: 创建 NOT(LIKE) operator structure.
         @Test
         void notLike_ShouldCreateNotLikeOperator() {
-            // when
-            builder.notLike("%test%");
+            TestExpressionBuilder result = builder.notLike("%test%");
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.NOT);
         }
 
-///
-         /// 测试目标: 验证y likeIfNotNull() with null returns EmptyNode.
-         /// 测试场景: Call likeIfNotNull() with null value.
-         /// 预期结果: Returns EmptyNode.
         @Test
         void likeIfNotNull_WhenNull_ShouldReturnEmptyNode() {
-            // when
-            builder.likeIfNotNull(null);
+            TestExpressionBuilder result = builder.likeIfNotNull(null);
 
-            // then
-            assertThat(capturedNode).isInstanceOf(EmptyNode.class);
+            assertThat(result.getRoot()).isInstanceOf(EmptyNode.class);
         }
 
-///
-         /// 测试目标: 验证y likeIfNotEmpty() with empty string returns EmptyNode.
-         /// 测试场景: Call likeIfNotEmpty() with empty string.
-         /// 预期结果: Returns EmptyNode.
         @Test
         void likeIfNotEmpty_WhenEmpty_ShouldReturnEmptyNode() {
-            // when
-            builder.likeIfNotEmpty("");
+            TestExpressionBuilder result = builder.likeIfNotEmpty("");
 
-            // then
-            assertThat(capturedNode).isInstanceOf(EmptyNode.class);
+            assertThat(result.getRoot()).isInstanceOf(EmptyNode.class);
         }
 
-///
-         /// 测试目标: 验证y likeIfNotEmpty() with non-empty creates LIKE.
-         /// 测试场景: Call likeIfNotEmpty() with non-empty string.
-         /// 预期结果: 创建 LIKE operator.
         @Test
         void likeIfNotEmpty_WhenNonEmpty_ShouldCreateLikeOperator() {
-            // when
-            builder.likeIfNotEmpty("test");
+            TestExpressionBuilder result = builder.likeIfNotEmpty("test");
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.LIKE);
         }
     }
@@ -421,20 +307,13 @@ class AbstractExpressionBuilderTest {
     @Nested
     class LogicalOperators {
 
-///
-         /// 测试目标: 验证y not() creates NOT operator node.
-         /// 测试场景: Call not().
-         /// 预期结果: 创建 operator node with NOT operator.
         @Test
         void not_ShouldCreateNotOperator() {
-            // when
-            builder.not();
+            TestExpressionBuilder result = builder.not();
 
-            // then
-            assertThat(capturedNode).isInstanceOf(OperatorNode.class);
-            OperatorNode opNode = (OperatorNode) capturedNode;
+            assertThat(result.getRoot()).isInstanceOf(OperatorNode.class);
+            OperatorNode opNode = (OperatorNode) result.getRoot();
             assertThat(opNode.operator()).isEqualTo(Operator.NOT);
         }
     }
 }
-

--- a/nextentity-examples/pom.xml
+++ b/nextentity-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.flow-entity</groupId>
         <artifactId>nextentity</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4</version>
     </parent>
 
     <artifactId>nextentity-examples</artifactId>

--- a/nextentity-spring/pom.xml
+++ b/nextentity-spring/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.flow-entity</groupId>
         <artifactId>nextentity</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4</version>
     </parent>
 
     <artifactId>nextentity-spring</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.flow-entity</groupId>
     <artifactId>nextentity</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.4</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## 摘要

- 为 `ExpressionBuilder` 和 `SimpleExpression` 接口添加空安全的集合条件运算符
- `inIfNotNull(Collection)`: 集合为 null 时跳过条件，非 null 时执行 IN 运算
- `notInIfNotNull(Collection)`: 集合为 null 时跳过条件，非 null 时执行 NOT IN 运算
- 重构测试类，移除冗余状态字段