### PR TITLE
feat: 支持 @Embedded 嵌入属性与 @AttributeOverride

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,19 @@ Recent history follows a Conventional Commit style such as `docs: ...`, `fix: ..
 
 ## Configuration Tips
 Do not commit real database credentials. Keep local overrides in environment-specific config, and treat files in `nextentity-examples/src/main/resources` as safe examples rather than production defaults.
+
+集成测试支持通过 `-Ddbc` 参数筛选要测试的数据库：
+
+```bash
+# 默认全部数据库（mysql, postgresql, sqlserver, h2）
+mvn test -pl nextentity-core
+
+# 只测试 H2（最快，无需容器）
+mvn test -pl nextentity-core -Ddbc=h2
+
+# 测试特定数据库
+mvn test -pl nextentity-core -Ddbc=mysql,postgresql
+mvn test -pl nextentity-core -Ddbc=mysql
+```
+
+支持的数据库类型：`mysql`、`postgresql`、`sqlserver`、`h2`

--- a/nextentity-core/src/main/java/io/github/nextentity/core/TransactionOperations.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/TransactionOperations.java
@@ -4,11 +4,9 @@ import java.util.function.Supplier;
 
 public interface TransactionOperations {
 
-    /**
-     * 在事务中执行给定的操作
-     *
-     * @param operation 要执行的操作
-     */
+    /// 在事务中执行给定的操作
+    ///
+    /// @param operation 要执行的操作
     default void executeInTransaction(Runnable operation) {
         executeInTransaction(() -> {
             operation.run();
@@ -16,13 +14,11 @@ public interface TransactionOperations {
         });
     }
 
-    /**
-     * 在事务中执行给定的操作，并返回结果
-     *
-     * @param operation 要执行的操作
-     * @param <T>       结果类型
-     * @return 操作结果
-     */
+    /// 在事务中执行给定的操作，并返回结果
+    ///
+    /// @param operation 要执行的操作
+    /// @param <T>       结果类型
+    /// @return 操作结果
     <T> T executeInTransaction(Supplier<T> operation);
 
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/constructor/EntityConstructorBuilder.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/constructor/EntityConstructorBuilder.java
@@ -35,15 +35,15 @@ public final class EntityConstructorBuilder {
         List<PropertyBinding> bindings = new ArrayList<>();
         for (EntityAttribute attr : schema.getAttributes()) {
             if (attr instanceof EntitySchemaAttribute schemaAttribute) {
-                boolean isEmbedded = schemaAttribute.schema().isEmbedded();
-                // 嵌入属性与主表共享同一张表，必须始终构造（不受 fetch 路径限制）
-                if (isEmbedded || paths.get(schemaAttribute.name()) != null) {
-                    SchemaAttributePaths sub = isEmbedded
-                            ? DeepLimitSchemaAttributePaths.of(1)
-                            : paths.get(schemaAttribute.name());
+                if (paths.get(schemaAttribute.name()) != null) {
+                    SchemaAttributePaths sub = paths.get(schemaAttribute.name());
                     ValueConstructor constructor = build(sub, schemaAttribute.schema());
                     bindings.add(new PropertyBinding(attr, constructor));
                 }
+            } else if (attr instanceof EmbeddedAttribute embeddedAttribute) {
+                SchemaAttributePaths sub = DeepLimitSchemaAttributePaths.of(1);
+                ValueConstructor constructor = build(sub, embeddedAttribute.schema());
+                bindings.add(new PropertyBinding(attr, constructor));
             } else if (attr instanceof EntityBasicAttribute basicAttribute) {
                 SelectItem column = SelectItem.of(basicAttribute);
                 bindings.add(new PropertyBinding(attr, new SingleValueConstructor(column)));

--- a/nextentity-core/src/main/java/io/github/nextentity/core/constructor/EntityConstructorBuilder.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/constructor/EntityConstructorBuilder.java
@@ -35,8 +35,12 @@ public final class EntityConstructorBuilder {
         List<PropertyBinding> bindings = new ArrayList<>();
         for (EntityAttribute attr : schema.getAttributes()) {
             if (attr instanceof EntitySchemaAttribute schemaAttribute) {
-                SchemaAttributePaths sub = paths.get(schemaAttribute.name());
-                if (sub != null) {
+                boolean isEmbedded = schemaAttribute.schema().isEmbedded();
+                // 嵌入属性与主表共享同一张表，必须始终构造（不受 fetch 路径限制）
+                if (isEmbedded || paths.get(schemaAttribute.name()) != null) {
+                    SchemaAttributePaths sub = isEmbedded
+                            ? DeepLimitSchemaAttributePaths.of(1)
+                            : paths.get(schemaAttribute.name());
                     ValueConstructor constructor = build(sub, schemaAttribute.schema());
                     bindings.add(new PropertyBinding(attr, constructor));
                 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/constructor/SelectItem.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/constructor/SelectItem.java
@@ -28,7 +28,7 @@ public sealed interface SelectItem permits SelectItem.Expr, SelectItem.Joined {
     /// @return SelectItem 实例
     static SelectItem of(EntityBasicAttribute attribute) {
         EntitySchema schema = attribute.declareBy();
-        if (schema instanceof EntitySchemaAttribute target && !target.schema().isEmbedded()) {
+        if (schema instanceof EntitySchemaAttribute target) {
             return new Joined(attribute, target);
         } else {
             return new Expr(attribute.path(), attribute.valueConvertor());

--- a/nextentity-core/src/main/java/io/github/nextentity/core/constructor/SelectItem.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/constructor/SelectItem.java
@@ -19,9 +19,16 @@ public sealed interface SelectItem permits SelectItem.Expr, SelectItem.Joined {
         return new Expr(expression, converter);
     }
 
+    /// 根据实体基本属性创建 SelectItem。
+    ///
+    /// 如果属性声明方是嵌入类型（{@code @Embedded}），嵌入字段与主表共享同一张表，
+    /// 因此使用 {@link Expr} 而非 {@link Joined}，避免生成错误的 JOIN 子句。
+    ///
+    /// @param attribute 实体基本属性
+    /// @return SelectItem 实例
     static SelectItem of(EntityBasicAttribute attribute) {
         EntitySchema schema = attribute.declareBy();
-        if (schema instanceof EntitySchemaAttribute target) {
+        if (schema instanceof EntitySchemaAttribute target && !target.schema().isEmbedded()) {
             return new Joined(attribute, target);
         } else {
             return new Expr(attribute.path(), attribute.valueConvertor());

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/EmbeddedAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/EmbeddedAttribute.java
@@ -1,0 +1,11 @@
+package io.github.nextentity.core.meta;
+
+public non-sealed interface EmbeddedAttribute extends EntityAttribute {
+
+    EntitySchema schema();
+
+    @Override
+    default boolean isPrimitive() {
+        return false;
+    }
+}

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/EntityAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/EntityAttribute.java
@@ -1,6 +1,5 @@
 package io.github.nextentity.core.meta;
 
-import io.github.nextentity.core.expression.ExpressionNode;
 import io.github.nextentity.core.expression.PathNode;
 
 /// 实体属性元数据接口，表示实体类中映射到数据库的字段或关联。
@@ -12,7 +11,7 @@ import io.github.nextentity.core.expression.PathNode;
 /// @see EntityBasicAttribute
 /// @see EntitySchemaAttribute
 public sealed interface EntityAttribute extends MetamodelAttribute
-        permits EntityBasicAttribute, EntitySchemaAttribute {
+        permits EmbeddedAttribute, EntityBasicAttribute, EntitySchemaAttribute {
 
     /// 获取此属性在查询表达式中的路径节点。
     ///

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/EntityBasicAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/EntityBasicAttribute.java
@@ -37,7 +37,7 @@ public non-sealed interface EntityBasicAttribute extends EntityAttribute {
     /// @param entity 实体实例
     /// @return 数据库值
     default Object getDatabaseValue(Object entity) {
-        Object o = get(entity);
+        Object o = declareBy().isEmbedded() ? getFromRoot(entity) : get(entity);
         return valueConvertor().convertToDatabaseColumn(TypeCastUtil.unsafeCast(o));
     }
 

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/EntityBasicAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/EntityBasicAttribute.java
@@ -37,7 +37,7 @@ public non-sealed interface EntityBasicAttribute extends EntityAttribute {
     /// @param entity 实体实例
     /// @return 数据库值
     default Object getDatabaseValue(Object entity) {
-        Object o = declareBy().isEmbedded() ? getFromRoot(entity) : get(entity);
+        Object o = declareBy() instanceof EmbeddedAttribute ? getFromRoot(entity) : get(entity);
         return valueConvertor().convertToDatabaseColumn(TypeCastUtil.unsafeCast(o));
     }
 

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/EntityType.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/EntityType.java
@@ -1,15 +1,11 @@
 package io.github.nextentity.core.meta;
 
-/**
- * 实体类型接口，扩展 EntitySchema 并提供投影支持。
- */
+/// 实体类型接口，扩展 EntitySchema 并提供投影支持。
 public interface EntityType extends EntitySchema {
 
-    /**
-     * 获取指定投影类的投影模式元数据。
-     *
-     * @param type 投影类
-     * @return 投影模式元数据
-     */
+    /// 获取指定投影类的投影模式元数据。
+    ///
+    /// @param type 投影类
+    /// @return 投影模式元数据
     ProjectionSchema getProjection(Class<?> type);
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/JoinAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/JoinAttribute.java
@@ -9,6 +9,14 @@ import jakarta.persistence.FetchType;
 public sealed interface JoinAttribute extends MetamodelAttribute
         permits EntitySchemaAttribute, ProjectionJoinAttribute, ProjectionSchemaAttribute {
 
+    /// 获取此连接属性指向的目标 Schema。
+    ///
+    /// 对于实体关联（{@link EntitySchemaAttribute}）返回目标实体 Schema；
+    /// 对于投影关联（{@link ProjectionSchemaAttribute}）返回目标投影 Schema。
+    ///
+    /// @return 目标 Schema
+    MetamodelSchema<?> schema();
+
     @Override
     default boolean isObject() {
         return true;

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelAttribute.java
@@ -104,6 +104,9 @@ public interface MetamodelAttribute {
         Object declared = root;
         if (schema instanceof MetamodelAttribute parent) {
             declared = parent.getFromRoot(declared);
+            if (declared == null) {
+                return null;
+            }
         }
         return accessor().get(declared);
     }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelAttribute.java
@@ -77,26 +77,47 @@ public interface MetamodelAttribute {
         return path().size();
     }
 
-    /// 从实体实例获取属性值。
+    /// 从指定对象实例中获取此属性的值。
     ///
+    /// 对象实例可以是根实体、嵌入对象或投影实例，只要它包含此属性的声明。
     /// 如果 getter 方法可访问则使用它，否则直接访问字段。
     ///
-    /// @param entity 实体实例
+    /// @param instance 包含此属性的对象实例
     /// @return 属性值
     /// @throws ReflectiveException 如果访问失败
-    default Object get(Object entity) {
-        return accessor().get(entity);
+    default Object get(Object instance) {
+        return accessor().get(instance);
     }
 
-    /// 在实体实例上设置属性值。
+    /// 从根实体开始沿声明链向下导航，获取此属性的值。
     ///
+    /// 与 {@link #get(Object)} 要求传入声明类型的实例不同，此方法
+    /// 接受根实体实例，自动遍历 {@code @Embedded} 属性链直到当前层级。
+    /// 例如对于 {@code address.zipCode} 属性，传入 {@code Person} 实例即可，
+    /// 方法会先获取 {@code address} 再获取 {@code zipCode}。
+    ///
+    /// @param root 根实体实例
+    /// @return 属性值
+    /// @throws ReflectiveException 如果访问失败
+    default Object getFromRoot(Object root) {
+        MetamodelSchema<?> schema = declareBy();
+        Object declared = root;
+        if (schema instanceof MetamodelAttribute parent) {
+            declared = parent.getFromRoot(declared);
+        }
+        return accessor().get(declared);
+    }
+
+    /// 在指定对象实例上设置属性值。
+    ///
+    /// 对象实例可以是根实体、嵌入对象或投影实例，只要它包含此属性的声明。
     /// 如果 setter 方法可访问则使用它，否则直接设置字段。
     ///
-    /// @param entity 实体实例
-    /// @param value  要设置的值
+    /// @param instance 包含此属性的对象实例
+    /// @param value    要设置的值
     /// @throws ReflectiveException 如果访问失败
-    default void set(Object entity, Object value) {
-        accessor().set(entity, value);
+    default void set(Object instance, Object value) {
+        accessor().set(instance, value);
     }
 
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelResolver.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelResolver.java
@@ -24,6 +24,12 @@ public interface MetamodelResolver {
     /// @return 如果是 transient 则返回 {@code true}
     boolean isTransient(Accessor accessor);
 
+    /// 检查属性是否为嵌入字段。
+    ///
+    /// @param accessor 属性访问器
+    /// @return 如果是嵌入字段则返回 {@code true}
+    boolean isEmbedded(Accessor accessor);
+
     /// 检查属性是否为基本字段（非关联字段）。
     ///
     /// @param accessor 属性访问器

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelResolver.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelResolver.java
@@ -4,6 +4,8 @@ import io.github.nextentity.core.meta.impl.DefaultEntitySchema;
 import io.github.nextentity.core.reflect.schema.Accessor;
 import jakarta.persistence.FetchType;
 
+import java.util.Map;
+
 /// 元模型解析器接口，从 JPA 注解中提取实体元数据。
 ///
 /// 负责将 JPA 注解（如 {@code @Column}、{@code @JoinColumn}、{@code @Id} 等）
@@ -150,4 +152,14 @@ public interface MetamodelResolver {
     /// @param attribute 要检查的属性
     /// @return 加载策略，或 {@code null} 表示使用全局默认
     FetchType getFetchType(MetamodelAttribute attribute);
+
+    /// 获取属性/类上的 @AttributeOverride 映射。
+    ///
+    /// @param accessor 字段访问器
+    /// @return 嵌入子字段名 → 覆盖列名，无覆盖时返回空 Map
+    Map<String, String> getAttributeOverrides(Accessor accessor);
+
+    /// @param type 实体类（用于 {@code @MappedSuperclass} 继承场景）
+    /// @return 嵌入子字段名 → 覆盖列名，无覆盖时返回空 Map
+    Map<String, String> getAttributeOverrides(Class<?> type);
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelSchema.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelSchema.java
@@ -70,12 +70,4 @@ public interface MetamodelSchema<T extends MetamodelAttribute> {
                 ? ma.path().get(name)
                 : new PathNode(name);
     }
-
-    /// 检查此模式是否为嵌入类型。
-    ///
-    /// 嵌入类型是指使用 {@code @Embedded} 注解的复合类型，
-    /// 其属性会展开到宿主实体对应的数据库表中。
-    ///
-    /// @return 如果是嵌入类型则返回 {@code true}
-    boolean isEmbedded();
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelSchema.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/MetamodelSchema.java
@@ -70,4 +70,12 @@ public interface MetamodelSchema<T extends MetamodelAttribute> {
                 ? ma.path().get(name)
                 : new PathNode(name);
     }
+
+    /// 检查此模式是否为嵌入类型。
+    ///
+    /// 嵌入类型是指使用 {@code @Embedded} 注解的复合类型，
+    /// 其属性会展开到宿主实体对应的数据库表中。
+    ///
+    /// @return 如果是嵌入类型则返回 {@code true}
+    boolean isEmbedded();
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/ProjectionJoinAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/ProjectionJoinAttribute.java
@@ -11,4 +11,9 @@ package io.github.nextentity.core.meta;
 /// @see ProjectionSchemaAttribute
 public non-sealed interface ProjectionJoinAttribute extends ProjectionAttribute, JoinAttribute {
 
+    /// 获取此自定义连接属性指向的目标投影 Schema。
+    ///
+    /// @return 目标投影 Schema
+    @Override
+    ProjectionSchema schema();
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/ProjectionSchemaAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/ProjectionSchemaAttribute.java
@@ -12,6 +12,10 @@ package io.github.nextentity.core.meta;
 /// @see JoinAttribute
 public non-sealed interface ProjectionSchemaAttribute extends ProjectionAttribute, JoinAttribute {
 
+    /// 获取此投影关联属性指向的目标投影 Schema。
+    ///
+    /// @return 目标投影 Schema
+    @Override
     ProjectionSchema schema();
 
     /// 获取此投影属性对应的实体关联属性。

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/AttributeSet.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/AttributeSet.java
@@ -1,6 +1,7 @@
 package io.github.nextentity.core.meta.impl;
 
 import io.github.nextentity.core.meta.MetamodelAttribute;
+import io.github.nextentity.core.meta.MetamodelSchema;
 import io.github.nextentity.core.util.ImmutableArray;
 import io.github.nextentity.core.util.ImmutableList;
 
@@ -17,11 +18,30 @@ public class AttributeSet<T extends MetamodelAttribute> {
         List<T> primitives = new ArrayList<>();
         for (T attribute : attributes) {
             index.put(attribute.name(), attribute);
-            if (attribute.isPrimitive()) {
-                primitives.add(attribute);
-            }
+            collectPrimitives(attribute, primitives);
         }
         this.primitives = ImmutableList.ofCollection(primitives);
+    }
+
+    /**
+     * 递归收集属性中的基本（非关联）属性。
+     *
+     * 如果属性本身是基本属性，直接添加到结果列表；
+     * 如果属性是嵌入类型，则递归遍历其内部的所有子属性，
+     * 将其中基本属性展开后收集到结果列表中。
+     *
+     * @param attribute 当前待收集的属性
+     * @param out       收集结果的输出列表
+     */
+    private void collectPrimitives(MetamodelAttribute attribute, List<T> out) {
+        if (attribute.isPrimitive()) {
+            //noinspection unchecked
+            out.add((T) attribute);
+        } else if (attribute instanceof MetamodelSchema<?> schema && schema.isEmbedded()) {
+            for (MetamodelAttribute child : schema.getAttributes()) {
+                collectPrimitives(child, out);
+            }
+        }
     }
 
     public Map<String, T> index() {

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/AttributeSet.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/AttributeSet.java
@@ -23,16 +23,13 @@ public class AttributeSet<T extends MetamodelAttribute> {
         this.primitives = ImmutableList.ofCollection(primitives);
     }
 
-    /**
-     * 递归收集属性中的基本（非关联）属性。
-     *
-     * 如果属性本身是基本属性，直接添加到结果列表；
-     * 如果属性是嵌入类型，则递归遍历其内部的所有子属性，
-     * 将其中基本属性展开后收集到结果列表中。
-     *
-     * @param attribute 当前待收集的属性
-     * @param out       收集结果的输出列表
-     */
+    /// 递归收集属性中的基本（非关联）属性。
+    /// 如果属性本身是基本属性，直接添加到结果列表；
+    /// 如果属性是嵌入类型，则递归遍历其内部的所有子属性，
+    /// 将其中基本属性展开后收集到结果列表中。
+    ///
+    /// @param attribute 当前待收集的属性
+    /// @param out       收集结果的输出列表
     private void collectPrimitives(MetamodelAttribute attribute, List<T> out) {
         if (attribute.isPrimitive()) {
             //noinspection unchecked

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/AttributeSet.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/AttributeSet.java
@@ -1,7 +1,7 @@
 package io.github.nextentity.core.meta.impl;
 
+import io.github.nextentity.core.meta.EmbeddedAttribute;
 import io.github.nextentity.core.meta.MetamodelAttribute;
-import io.github.nextentity.core.meta.MetamodelSchema;
 import io.github.nextentity.core.util.ImmutableArray;
 import io.github.nextentity.core.util.ImmutableList;
 
@@ -37,8 +37,8 @@ public class AttributeSet<T extends MetamodelAttribute> {
         if (attribute.isPrimitive()) {
             //noinspection unchecked
             out.add((T) attribute);
-        } else if (attribute instanceof MetamodelSchema<?> schema && schema.isEmbedded()) {
-            for (MetamodelAttribute child : schema.getAttributes()) {
+        } else if (attribute instanceof EmbeddedAttribute embeddedAttribute) {
+            for (MetamodelAttribute child : embeddedAttribute.schema().getAttributes()) {
                 collectPrimitives(child, out);
             }
         }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEmbeddedAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEmbeddedAttribute.java
@@ -1,0 +1,104 @@
+package io.github.nextentity.core.meta.impl;
+
+import io.github.nextentity.core.TypeCastUtil;
+import io.github.nextentity.core.expression.PathNode;
+import io.github.nextentity.core.meta.EmbeddedAttribute;
+import io.github.nextentity.core.meta.EntityAttribute;
+import io.github.nextentity.core.meta.EntitySchema;
+import io.github.nextentity.core.meta.MetamodelAttribute;
+import io.github.nextentity.core.reflect.schema.Accessor;
+import io.github.nextentity.core.reflect.schema.impl.DefaultAccessor;
+import io.github.nextentity.core.util.Lazy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class DefaultEmbeddedAttribute extends DefaultEntitySchema implements EmbeddedAttribute {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultEmbeddedAttribute.class);
+
+    private final Accessor accessor;
+    private final DefaultEntitySchema declareBy;
+    private final PathNode path;
+
+    public DefaultEmbeddedAttribute(MetamodelAttribute attribute,
+                                    DefaultEntitySchema declareBy,
+                                    DefaultMetamodel metamodel) {
+        super(attribute.type(), metamodel);
+        this.declareBy = declareBy;
+        this.accessor = attribute.accessor();
+        this.path = declareBy.getPath(attribute.name());
+    }
+
+    @Override
+    protected Lazy<? extends AttributeSet<EntityAttribute>> getAttributesSupplier() {
+        return TypeCastUtil.unsafeCast(super.getAttributesSupplier());
+    }
+
+    @Override
+    public Accessor accessor() {
+        return accessor;
+    }
+
+    @Override
+    public DefaultEntitySchema declareBy() {
+        return declareBy;
+    }
+
+    @Override
+    public PathNode path() {
+        return this.path;
+    }
+
+    @Override
+    protected AttributeSet<EntityAttribute> createAttributes() {
+        Map<String, String> attributeOverrides = getAttributeOverrides();
+        List<DefaultAccessor> accessors = DefaultAccessor.of(type());
+        ArrayList<EntityAttribute> attributes = new ArrayList<>();
+        for (DefaultAccessor accessor : accessors) {
+            if (resolver.isTransient(accessor)) {
+                continue;
+            }
+            boolean isComplexType = !DefaultAccessor.of(accessor.type()).isEmpty();
+            DefaultMetamodelAttribute attr = new DefaultMetamodelAttribute(this, accessor);
+            if (isComplexType && resolver.isEmbedded(accessor)) {
+                attributes.add(new DefaultEmbeddedAttribute(attr, this, metamodel));
+            } else if (resolver.isBasicField(accessor)) {
+                String columnName = attributeOverrides.getOrDefault(
+                        accessor.name(),
+                        resolver.getColumnName(accessor)
+                );
+                attributes.add(new DefaultEntityBasicAttribute(
+                        attr, this, resolver, columnName));
+            } else {
+                log.warn("ignored attribute {}", accessor.field());
+            }
+        }
+        return new AttributeSet<>(attributes);
+    }
+
+    /// 合并当前字段的 @AttributeOverride 与父级传递的点号路径覆盖。
+    /// 如父级的 address.street 在当前层级为 address 时，截取前缀后变为 street。
+    protected Map<String, String> getAttributeOverrides() {
+        Map<String, String> overrides = resolver.getAttributeOverrides(accessor);
+        Map<String, String> parent = declareBy().getAttributeOverrides();
+        for (Map.Entry<String, String> entry : parent.entrySet()) {
+            String[] split = entry.getKey().split("\\.");
+            if (split.length > 1 && split[0].equals(name())) {
+                String key = Arrays.stream(split).skip(1)
+                        .collect(Collectors.joining("."));
+                overrides.put(key, entry.getValue());
+            }
+        }
+        return overrides;
+    }
+
+    @Override
+    public EntitySchema schema() {
+        return this;
+    }
+
+}

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntityBasicAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntityBasicAttribute.java
@@ -11,8 +11,15 @@ public class DefaultEntityBasicAttribute extends DefaultMetamodelAttribute imple
     public DefaultEntityBasicAttribute(MetamodelAttribute attribute,
                                        DefaultEntitySchema declareBy,
                                        MetamodelResolver resolver) {
+        this(attribute, declareBy, resolver, resolver.getColumnName(attribute.accessor()));
+    }
+
+    public DefaultEntityBasicAttribute(MetamodelAttribute attribute,
+                                       DefaultEntitySchema declareBy,
+                                       MetamodelResolver resolver,
+                                       String columnName) {
         super(declareBy, attribute.accessor(), declareBy.getPath(attribute.name()));
-        this.columnName = resolver.getColumnName(attribute.accessor());
+        this.columnName = columnName;
         this.updatable = resolver.isUpdatable(attribute.accessor());
         this.valueConverter = resolver.databaseType(attribute.accessor());
     }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchema.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchema.java
@@ -144,4 +144,9 @@ public class DefaultEntitySchema extends AbstractMetamodelSchema<EntityAttribute
     protected Lazy<? extends AttributeSet<EntityAttribute>> getAttributesSupplier() {
         return attributesSupplier;
     }
+
+    /// 获取当前实体/嵌入类型上的 @AttributeOverride / @AttributeOverrides 映射。
+    protected Map<String, String> getAttributeOverrides() {
+        return resolver.getAttributeOverrides(type());
+    }
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchema.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchema.java
@@ -38,7 +38,7 @@ public class DefaultEntitySchema extends AbstractMetamodelSchema<EntityAttribute
 
     @Override
     public EntityBasicAttribute id() {
-        return ((EntityAttributeSet) attributesSupplier.get()).id();
+        return attributesSupplier.get() instanceof EntityAttributeSet entityAttributeSet ? entityAttributeSet.id() : null;
     }
 
     @Override
@@ -53,22 +53,12 @@ public class DefaultEntitySchema extends AbstractMetamodelSchema<EntityAttribute
 
     @Override
     public EntityBasicAttribute version() {
-        return ((EntityAttributeSet) attributesSupplier.get()).version();
+        return attributesSupplier.get() instanceof EntityAttributeSet eas ? eas.version() : null;
     }
 
     @Override
     public EntityAttribute getAttribute(Iterable<String> fieldNames) {
         return super.getAttribute(fieldNames);
-    }
-
-    /**
-     * 实体模式本身不是嵌入类型，始终返回 {@code false}。
-     *
-     * @return {@code false}
-     */
-    @Override
-    public boolean isEmbedded() {
-        return false;
     }
 
     @Override
@@ -96,9 +86,14 @@ public class DefaultEntitySchema extends AbstractMetamodelSchema<EntityAttribute
             boolean isComplexType = !DefaultAccessor.of(accessor.type()).isEmpty();
             DefaultMetamodelAttribute attr = new DefaultMetamodelAttribute(this, accessor);
             if (isComplexType && (resolver.isAnyToOne(attr) || resolver.isEmbedded(accessor))) {
-                var entitySchemaAttribute = new DefaultEntitySchemaAttribute(
-                        attr, this, metamodel);
-                attributes.add(entitySchemaAttribute);
+                if (resolver.isEmbedded(accessor)) {
+                    var embeddedAttribute = new DefaultEmbeddedAttribute(attr, this, metamodel);
+                    attributes.add(embeddedAttribute);
+                } else {
+                    var entitySchemaAttribute = new DefaultEntitySchemaAttribute(
+                            attr, this, metamodel);
+                    attributes.add(entitySchemaAttribute);
+                }
             } else if (resolver.isBasicField(accessor)) {
                 boolean versionField = false;
                 if (resolver.isVersionField(accessor)) {
@@ -131,7 +126,7 @@ public class DefaultEntitySchema extends AbstractMetamodelSchema<EntityAttribute
                 }
             }
             idAttribute = found;
-            if (idAttribute == null && !isEmbedded()) {
+            if (idAttribute == null && !(this instanceof EmbeddedAttribute)) {
                 throw new ConfigurationException(
                         "No ID attribute found for entity '" + entityName + "' (" + type.getName() + "). " +
                         "Please annotate the ID field with @Id or ensure a field named 'id' exists.");

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchema.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchema.java
@@ -95,7 +95,7 @@ public class DefaultEntitySchema extends AbstractMetamodelSchema<EntityAttribute
             }
             boolean isComplexType = !DefaultAccessor.of(accessor.type()).isEmpty();
             DefaultMetamodelAttribute attr = new DefaultMetamodelAttribute(this, accessor);
-            if (isComplexType && resolver.isAnyToOne(attr)) {
+            if (isComplexType && (resolver.isAnyToOne(attr) || resolver.isEmbedded(accessor))) {
                 var entitySchemaAttribute = new DefaultEntitySchemaAttribute(
                         attr, this, metamodel);
                 attributes.add(entitySchemaAttribute);
@@ -131,7 +131,7 @@ public class DefaultEntitySchema extends AbstractMetamodelSchema<EntityAttribute
                 }
             }
             idAttribute = found;
-            if (idAttribute == null) {
+            if (idAttribute == null && !isEmbedded()) {
                 throw new ConfigurationException(
                         "No ID attribute found for entity '" + entityName + "' (" + type.getName() + "). " +
                         "Please annotate the ID field with @Id or ensure a field named 'id' exists.");

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchema.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchema.java
@@ -61,6 +61,16 @@ public class DefaultEntitySchema extends AbstractMetamodelSchema<EntityAttribute
         return super.getAttribute(fieldNames);
     }
 
+    /**
+     * 实体模式本身不是嵌入类型，始终返回 {@code false}。
+     *
+     * @return {@code false}
+     */
+    @Override
+    public boolean isEmbedded() {
+        return false;
+    }
+
     @Override
     public EntityAttribute getAttribute(String name) {
         return super.getAttribute(name);

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchema.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchema.java
@@ -10,10 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * 默认实体类型实现，实现 EntityType 接口。
- * 提供实体元数据的核心实现，包括属性、表名、版本字段、投影等。
- */
+/// 默认实体类型实现，实现 EntityType 接口。
+/// 提供实体元数据的核心实现，包括属性、表名、版本字段、投影等。
 public class DefaultEntitySchema extends AbstractMetamodelSchema<EntityAttribute> implements EntityType {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultEntitySchema.class);

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchemaAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchemaAttribute.java
@@ -5,6 +5,7 @@ import io.github.nextentity.core.exception.ConfigurationException;
 import io.github.nextentity.core.expression.PathNode;
 import io.github.nextentity.core.meta.*;
 import io.github.nextentity.core.reflect.schema.Accessor;
+import io.github.nextentity.core.reflect.schema.impl.DefaultAccessor;
 import io.github.nextentity.core.util.ImmutableArray;
 import io.github.nextentity.core.util.Lazy;
 import jakarta.persistence.FetchType;
@@ -16,6 +17,8 @@ import java.util.List;
 public class DefaultEntitySchemaAttribute
         extends DefaultEntitySchema
         implements EntitySchemaAttribute {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultEntitySchemaAttribute.class);
 
     private final Accessor accessor;
     private final DefaultEntitySchema declareBy;
@@ -95,34 +98,51 @@ public class DefaultEntitySchemaAttribute
 
     @Override
     protected AttributeSet<EntityAttribute> createAttributes() {
-        DefaultEntitySchema schema = DefaultEntitySchema.of(type(), metamodel);
-        ImmutableArray<? extends EntityAttribute> entityAttributes = schema.getAttributes();
-        List<EntityAttribute> entityAttributeList = new ArrayList<>(entityAttributes.size());
-        EntityBasicAttribute id = null;
-        EntityBasicAttribute version = null;
-        for (EntityAttribute attribute : entityAttributes) {
-            EntityAttribute cur;
-            if (attribute instanceof EntityBasicAttribute basicAttribute) {
-                var attr = new DefaultEntityBasicAttribute(basicAttribute, this, resolver);
-                cur = attr;
-                if (basicAttribute.isId()) {
-                    id = attr;
-                } else if (basicAttribute.isVersion()) {
-                    version = attr;
+        if (isEmbedded()) {
+            List<DefaultAccessor> accessors = DefaultAccessor.of(type());
+            ArrayList<EntityAttribute> attributes = new ArrayList<>();
+            for (DefaultAccessor accessor : accessors) {
+                if (resolver.isTransient(accessor)) {
+                    continue;
                 }
-            } else if (attribute instanceof EntitySchemaAttribute schemaAttribute) {
-                cur = new DefaultEntitySchemaAttribute(schemaAttribute, this, metamodel);
-            } else {
-                throw new ConfigurationException(
-                        "Unknown entity attribute type '" + attribute.getClass().getName() +
-                        "' when resolving schema attribute '" + this.path +
-                        "' for entity '" + type().getName() + "'.");
+                boolean isComplexType = !DefaultAccessor.of(accessor.type()).isEmpty();
+                DefaultMetamodelAttribute attr = new DefaultMetamodelAttribute(this, accessor);
+                if (isComplexType && resolver.isEmbedded(accessor)) {
+                    attributes.add(new DefaultEntitySchemaAttribute(attr, this, metamodel));
+                } else if (resolver.isBasicField(accessor)) {
+                    attributes.add(new DefaultEntityBasicAttribute(attr, this, resolver));
+                } else {
+                    log.warn("ignored attribute {}", accessor.field());
+                }
             }
-            entityAttributeList.add(cur);
+            return new Attributes(attributes, null, null, null, null);
+        } else {
+            DefaultEntitySchema schema = DefaultEntitySchema.of(type(), metamodel);
+            ImmutableArray<? extends EntityAttribute> entityAttributes = schema.getAttributes();
+            List<EntityAttribute> entityAttributeList = new ArrayList<>(entityAttributes.size());
+            EntityBasicAttribute id = null;
+            EntityBasicAttribute version = null;
+            for (EntityAttribute attribute : entityAttributes) {
+                EntityAttribute cur;
+                if (attribute instanceof EntityBasicAttribute basicAttribute) {
+                    var attr = new DefaultEntityBasicAttribute(basicAttribute, this, resolver);
+                    cur = attr;
+                    if (basicAttribute.isId()) {
+                        id = attr;
+                    } else if (basicAttribute.isVersion()) {
+                        version = attr;
+                    }
+                } else if (attribute instanceof EntitySchemaAttribute schemaAttribute) {
+                    cur = new DefaultEntitySchemaAttribute(schemaAttribute, this, metamodel);
+                } else {
+                    throw new ConfigurationException("Unknown entity attribute type '" + attribute.getClass().getName() + "' when resolving schema attribute '" + this.path + "' for entity '" + type().getName() + "'.");
+                }
+                entityAttributeList.add(cur);
+            }
+            var sourceAttribute = resolver.getJoinSourceAttribute(declareBy(), accessor());
+            var targetAttribute = resolver.getJoinTargetAttribute(schema, accessor());
+            return new Attributes(entityAttributeList, id, version, sourceAttribute, targetAttribute);
         }
-        var sourceAttribute = resolver.getJoinSourceAttribute(declareBy(), accessor());
-        var targetAttribute = resolver.getJoinTargetAttribute(schema, accessor());
-        return new Attributes(entityAttributeList, id, version, sourceAttribute, targetAttribute);
     }
 
     @Override

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchemaAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchemaAttribute.java
@@ -10,9 +10,8 @@ import io.github.nextentity.core.util.ImmutableArray;
 import io.github.nextentity.core.util.Lazy;
 import jakarta.persistence.FetchType;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class DefaultEntitySchemaAttribute
         extends DefaultEntitySchema
@@ -99,6 +98,7 @@ public class DefaultEntitySchemaAttribute
     @Override
     protected AttributeSet<EntityAttribute> createAttributes() {
         if (isEmbedded()) {
+            Map<String, String> attributeOverrides = getAttributeOverrides();
             List<DefaultAccessor> accessors = DefaultAccessor.of(type());
             ArrayList<EntityAttribute> attributes = new ArrayList<>();
             for (DefaultAccessor accessor : accessors) {
@@ -110,7 +110,12 @@ public class DefaultEntitySchemaAttribute
                 if (isComplexType && resolver.isEmbedded(accessor)) {
                     attributes.add(new DefaultEntitySchemaAttribute(attr, this, metamodel));
                 } else if (resolver.isBasicField(accessor)) {
-                    attributes.add(new DefaultEntityBasicAttribute(attr, this, resolver));
+                    String columnName = attributeOverrides.getOrDefault(
+                            accessor.name(),
+                            resolver.getColumnName(accessor)
+                    );
+                    attributes.add(new DefaultEntityBasicAttribute(
+                            attr, this, resolver, columnName));
                 } else {
                     log.warn("ignored attribute {}", accessor.field());
                 }
@@ -143,6 +148,22 @@ public class DefaultEntitySchemaAttribute
             var targetAttribute = resolver.getJoinTargetAttribute(schema, accessor());
             return new Attributes(entityAttributeList, id, version, sourceAttribute, targetAttribute);
         }
+    }
+
+    /// 合并当前字段的 @AttributeOverride 与父级传递的点号路径覆盖。
+    /// 如父级的 address.street 在当前层级为 address 时，截取前缀后变为 street。
+    protected Map<String, String> getAttributeOverrides() {
+        Map<String, String> overrides = resolver.getAttributeOverrides(accessor);
+        Map<String, String> parent = declareBy().getAttributeOverrides();
+        for (Map.Entry<String, String> entry : parent.entrySet()) {
+            String[] split = entry.getKey().split("\\.");
+            if (split.length > 1 && split[0].equals(name())) {
+                String key = Arrays.stream(split).skip(1)
+                        .collect(Collectors.joining("."));
+                overrides.put(key, entry.getValue());
+            }
+        }
+        return overrides;
     }
 
     @Override

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchemaAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchemaAttribute.java
@@ -21,6 +21,8 @@ public class DefaultEntitySchemaAttribute
     private final DefaultEntitySchema declareBy;
     private final PathNode path;
     private final FetchType fetchType;
+    /** 标记该属性是否为嵌入字段（{@code @Embedded}） */
+    private final boolean embedded;
 
     protected static class Attributes extends EntityAttributeSet {
         private final EntityBasicAttribute sourceAttribute;
@@ -53,6 +55,7 @@ public class DefaultEntitySchemaAttribute
         this.accessor = attribute.accessor();
         this.path = declareBy.getPath(attribute.name());
         this.fetchType = resolver.getFetchType(this);
+        this.embedded = resolver.isEmbedded(accessor);
     }
 
     @Override
@@ -130,5 +133,15 @@ public class DefaultEntitySchemaAttribute
     @Override
     public EntitySchema schema() {
         return this;
+    }
+
+    /**
+     * 返回该属性是否为嵌入字段。
+     *
+     * @return 如果是 {@code @Embedded} 注解的嵌入字段则返回 {@code true}
+     */
+    @Override
+    public boolean isEmbedded() {
+        return embedded;
     }
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchemaAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultEntitySchemaAttribute.java
@@ -5,7 +5,6 @@ import io.github.nextentity.core.exception.ConfigurationException;
 import io.github.nextentity.core.expression.PathNode;
 import io.github.nextentity.core.meta.*;
 import io.github.nextentity.core.reflect.schema.Accessor;
-import io.github.nextentity.core.reflect.schema.impl.DefaultAccessor;
 import io.github.nextentity.core.util.ImmutableArray;
 import io.github.nextentity.core.util.Lazy;
 import jakarta.persistence.FetchType;
@@ -23,8 +22,6 @@ public class DefaultEntitySchemaAttribute
     private final DefaultEntitySchema declareBy;
     private final PathNode path;
     private final FetchType fetchType;
-    /** 标记该属性是否为嵌入字段（{@code @Embedded}） */
-    private final boolean embedded;
 
     protected static class Attributes extends EntityAttributeSet {
         private final EntityBasicAttribute sourceAttribute;
@@ -57,7 +54,6 @@ public class DefaultEntitySchemaAttribute
         this.accessor = attribute.accessor();
         this.path = declareBy.getPath(attribute.name());
         this.fetchType = resolver.getFetchType(this);
-        this.embedded = resolver.isEmbedded(accessor);
     }
 
     @Override
@@ -97,57 +93,34 @@ public class DefaultEntitySchemaAttribute
 
     @Override
     protected AttributeSet<EntityAttribute> createAttributes() {
-        if (isEmbedded()) {
-            Map<String, String> attributeOverrides = getAttributeOverrides();
-            List<DefaultAccessor> accessors = DefaultAccessor.of(type());
-            ArrayList<EntityAttribute> attributes = new ArrayList<>();
-            for (DefaultAccessor accessor : accessors) {
-                if (resolver.isTransient(accessor)) {
-                    continue;
-                }
-                boolean isComplexType = !DefaultAccessor.of(accessor.type()).isEmpty();
-                DefaultMetamodelAttribute attr = new DefaultMetamodelAttribute(this, accessor);
-                if (isComplexType && resolver.isEmbedded(accessor)) {
-                    attributes.add(new DefaultEntitySchemaAttribute(attr, this, metamodel));
-                } else if (resolver.isBasicField(accessor)) {
-                    String columnName = attributeOverrides.getOrDefault(
-                            accessor.name(),
-                            resolver.getColumnName(accessor)
-                    );
-                    attributes.add(new DefaultEntityBasicAttribute(
-                            attr, this, resolver, columnName));
-                } else {
-                    log.warn("ignored attribute {}", accessor.field());
-                }
-            }
-            return new Attributes(attributes, null, null, null, null);
-        } else {
-            DefaultEntitySchema schema = DefaultEntitySchema.of(type(), metamodel);
-            ImmutableArray<? extends EntityAttribute> entityAttributes = schema.getAttributes();
-            List<EntityAttribute> entityAttributeList = new ArrayList<>(entityAttributes.size());
-            EntityBasicAttribute id = null;
-            EntityBasicAttribute version = null;
-            for (EntityAttribute attribute : entityAttributes) {
-                EntityAttribute cur;
-                if (attribute instanceof EntityBasicAttribute basicAttribute) {
-                    var attr = new DefaultEntityBasicAttribute(basicAttribute, this, resolver);
+        DefaultEntitySchema schema = DefaultEntitySchema.of(type(), metamodel);
+        ImmutableArray<? extends EntityAttribute> entityAttributes = schema.getAttributes();
+        List<EntityAttribute> entityAttributeList = new ArrayList<>(entityAttributes.size());
+        EntityBasicAttribute id = null;
+        EntityBasicAttribute version = null;
+        for (EntityAttribute attribute : entityAttributes) {
+            EntityAttribute cur;
+            switch (attribute) {
+                case EntityBasicAttribute basic -> {
+                    var attr = new DefaultEntityBasicAttribute(basic, this, resolver);
                     cur = attr;
-                    if (basicAttribute.isId()) {
+                    if (basic.isId()) {
                         id = attr;
-                    } else if (basicAttribute.isVersion()) {
+                    } else if (basic.isVersion()) {
                         version = attr;
                     }
-                } else if (attribute instanceof EntitySchemaAttribute schemaAttribute) {
-                    cur = new DefaultEntitySchemaAttribute(schemaAttribute, this, metamodel);
-                } else {
-                    throw new ConfigurationException("Unknown entity attribute type '" + attribute.getClass().getName() + "' when resolving schema attribute '" + this.path + "' for entity '" + type().getName() + "'.");
                 }
-                entityAttributeList.add(cur);
+                case EmbeddedAttribute embedded -> cur = new DefaultEmbeddedAttribute(embedded, this, metamodel);
+                case EntitySchemaAttribute schemaAttribute ->
+                        cur = new DefaultEntitySchemaAttribute(schemaAttribute, this, metamodel);
+                default ->
+                        throw new ConfigurationException("Unknown entity attribute type '" + attribute.getClass().getName() + "' when resolving schema attribute '" + this.path + "' for entity '" + type().getName() + "'.");
             }
-            var sourceAttribute = resolver.getJoinSourceAttribute(declareBy(), accessor());
-            var targetAttribute = resolver.getJoinTargetAttribute(schema, accessor());
-            return new Attributes(entityAttributeList, id, version, sourceAttribute, targetAttribute);
+            entityAttributeList.add(cur);
         }
+        var sourceAttribute = resolver.getJoinSourceAttribute(declareBy(), accessor());
+        var targetAttribute = resolver.getJoinTargetAttribute(schema, accessor());
+        return new Attributes(entityAttributeList, id, version, sourceAttribute, targetAttribute);
     }
 
     /// 合并当前字段的 @AttributeOverride 与父级传递的点号路径覆盖。
@@ -176,13 +149,4 @@ public class DefaultEntitySchemaAttribute
         return this;
     }
 
-    /**
-     * 返回该属性是否为嵌入字段。
-     *
-     * @return 如果是 {@code @Embedded} 注解的嵌入字段则返回 {@code true}
-     */
-    @Override
-    public boolean isEmbedded() {
-        return embedded;
-    }
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultMetamodelResolver.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultMetamodelResolver.java
@@ -317,36 +317,27 @@ public class DefaultMetamodelResolver implements MetamodelResolver {
 
     @Override
     public Map<String, String> getAttributeOverrides(Accessor accessor) {
-        Map<String, String> overrides = new HashMap<>();
         AttributeOverride single = getAnnotation(accessor, AttributeOverride.class);
-        if (single != null && !single.name().isEmpty()) {
-            String column = single.column().name();
-            if (!column.isEmpty()) {
-                overrides.put(single.name(), column);
-            }
-        }
         AttributeOverrides multiple = getAnnotation(accessor, AttributeOverrides.class);
-        if (multiple != null) {
-            for (AttributeOverride ao : multiple.value()) {
-                if (!ao.name().isEmpty() && !ao.column().name().isEmpty()) {
-                    overrides.put(ao.name(), ao.column().name());
-                }
-            }
-        }
-        return overrides;
+        return getStringStringMap(single, multiple);
     }
+
 
     @Override
     public Map<String, String> getAttributeOverrides(Class<?> type) {
-        Map<String, String> overrides = new HashMap<>();
         AttributeOverride single = type.getAnnotation(AttributeOverride.class);
+        AttributeOverrides multiple = type.getAnnotation(AttributeOverrides.class);
+        return getStringStringMap(single, multiple);
+    }
+
+    protected Map<String, String> getStringStringMap(AttributeOverride single, AttributeOverrides multiple) {
+        Map<String, String> overrides = new HashMap<>();
         if (single != null && !single.name().isEmpty()) {
             String column = single.column().name();
             if (!column.isEmpty()) {
                 overrides.put(single.name(), column);
             }
         }
-        AttributeOverrides multiple = type.getAnnotation(AttributeOverrides.class);
         if (multiple != null) {
             for (AttributeOverride ao : multiple.value()) {
                 if (!ao.name().isEmpty() && !ao.column().name().isEmpty()) {

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultMetamodelResolver.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultMetamodelResolver.java
@@ -24,13 +24,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * JPA 注解元模型解析器实现。
- * 从 JPA 注解提取实体元数据（表名、列名、关系等）。
- *
- * @author HuangChengwei
- * @since 2.0.0
- */
+/// JPA 注解元模型解析器实现。
+/// 从 JPA 注解提取实体元数据（表名、列名、关系等）。
+///
+/// @author HuangChengwei
+/// @since 2.0.0
 public class DefaultMetamodelResolver implements MetamodelResolver {
 
     private static final DefaultMetamodelResolver DEFAULT_INSTANCE = new DefaultMetamodelResolver();
@@ -97,12 +95,10 @@ public class DefaultMetamodelResolver implements MetamodelResolver {
                || getAnnotation(accessor, Transient.class) != null;
     }
 
-    /**
-     * 检查访问器对应的属性是否标记了 {@code @Embedded} 注解。
-     *
-     * @param accessor 属性访问器
-     * @return 存在 {@code @Embedded} 注解则返回 {@code true}
-     */
+    /// 检查访问器对应的属性是否标记了 `@Embedded` 注解。
+    ///
+    /// @param accessor 属性访问器
+    /// @return 存在 `@Embedded` 注解则返回 `true`
     @Override
     public boolean isEmbedded(Accessor accessor) {
         return getAnnotation(accessor, Embedded.class) != null;

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultMetamodelResolver.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultMetamodelResolver.java
@@ -20,7 +20,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * JPA 注解元模型解析器实现。
@@ -311,6 +313,48 @@ public class DefaultMetamodelResolver implements MetamodelResolver {
         }
 
         return fetchType;
+    }
+
+    @Override
+    public Map<String, String> getAttributeOverrides(Accessor accessor) {
+        Map<String, String> overrides = new HashMap<>();
+        AttributeOverride single = getAnnotation(accessor, AttributeOverride.class);
+        if (single != null && !single.name().isEmpty()) {
+            String column = single.column().name();
+            if (!column.isEmpty()) {
+                overrides.put(single.name(), column);
+            }
+        }
+        AttributeOverrides multiple = getAnnotation(accessor, AttributeOverrides.class);
+        if (multiple != null) {
+            for (AttributeOverride ao : multiple.value()) {
+                if (!ao.name().isEmpty() && !ao.column().name().isEmpty()) {
+                    overrides.put(ao.name(), ao.column().name());
+                }
+            }
+        }
+        return overrides;
+    }
+
+    @Override
+    public Map<String, String> getAttributeOverrides(Class<?> type) {
+        Map<String, String> overrides = new HashMap<>();
+        AttributeOverride single = type.getAnnotation(AttributeOverride.class);
+        if (single != null && !single.name().isEmpty()) {
+            String column = single.column().name();
+            if (!column.isEmpty()) {
+                overrides.put(single.name(), column);
+            }
+        }
+        AttributeOverrides multiple = type.getAnnotation(AttributeOverrides.class);
+        if (multiple != null) {
+            for (AttributeOverride ao : multiple.value()) {
+                if (!ao.name().isEmpty() && !ao.column().name().isEmpty()) {
+                    overrides.put(ao.name(), ao.column().name());
+                }
+            }
+        }
+        return overrides;
     }
 
     protected <T extends Annotation> T getAnnotation(Accessor accessor, Class<T> annotationClass) {

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultMetamodelResolver.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultMetamodelResolver.java
@@ -95,6 +95,17 @@ public class DefaultMetamodelResolver implements MetamodelResolver {
                || getAnnotation(accessor, Transient.class) != null;
     }
 
+    /**
+     * 检查访问器对应的属性是否标记了 {@code @Embedded} 注解。
+     *
+     * @param accessor 属性访问器
+     * @return 存在 {@code @Embedded} 注解则返回 {@code true}
+     */
+    @Override
+    public boolean isEmbedded(Accessor accessor) {
+        return getAnnotation(accessor, Embedded.class) != null;
+    }
+
     @Override
     public boolean isBasicField(Accessor accessor) {
         for (Class<? extends Annotation> type : JOIN_ANNOTATIONS) {

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultProjectionJoinAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultProjectionJoinAttribute.java
@@ -57,6 +57,14 @@ public class DefaultProjectionJoinAttribute
         return sourceAttribute;
     }
 
+    /// 获取此自定义连接属性的目标投影 Schema（自身即为投影 Schema）。
+    ///
+    /// @return 当前实例
+    @Override
+    public ProjectionSchema schema() {
+        return this;
+    }
+
     @Override
     public EntityType getTargetEntityType() {
         return target;

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultProjectionSchema.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultProjectionSchema.java
@@ -102,16 +102,6 @@ public class DefaultProjectionSchema
         return super.getAttribute(fieldNames);
     }
 
-    /**
-     * 投影模式本身不是嵌入类型，始终返回 {@code false}。
-     *
-     * @return {@code false}
-     */
-    @Override
-    public boolean isEmbedded() {
-        return false;
-    }
-
     @Override
     public ProjectionAttribute getAttribute(String name) {
         return super.getAttribute(name);

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultProjectionSchema.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultProjectionSchema.java
@@ -102,6 +102,16 @@ public class DefaultProjectionSchema
         return super.getAttribute(fieldNames);
     }
 
+    /**
+     * 投影模式本身不是嵌入类型，始终返回 {@code false}。
+     *
+     * @return {@code false}
+     */
+    @Override
+    public boolean isEmbedded() {
+        return false;
+    }
+
     @Override
     public ProjectionAttribute getAttribute(String name) {
         return super.getAttribute(name);

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultProjectionSchemaAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultProjectionSchemaAttribute.java
@@ -93,4 +93,14 @@ public class DefaultProjectionSchemaAttribute
     public ProjectionSchema schema() {
         return this;
     }
+
+    /**
+     * 委托到源实体属性判断是否为嵌入类型。
+     *
+     * @return 如果源属性是嵌入类型则返回 {@code true}
+     */
+    @Override
+    public boolean isEmbedded() {
+        return source.schema().isEmbedded();
+    }
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultProjectionSchemaAttribute.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/DefaultProjectionSchemaAttribute.java
@@ -93,14 +93,4 @@ public class DefaultProjectionSchemaAttribute
     public ProjectionSchema schema() {
         return this;
     }
-
-    /**
-     * 委托到源实体属性判断是否为嵌入类型。
-     *
-     * @return 如果源属性是嵌入类型则返回 {@code true}
-     */
-    @Override
-    public boolean isEmbedded() {
-        return source.schema().isEmbedded();
-    }
 }

--- a/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/ProjectionAttributeFactory.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/core/meta/impl/ProjectionAttributeFactory.java
@@ -2,10 +2,8 @@ package io.github.nextentity.core.meta.impl;
 
 import io.github.nextentity.core.meta.*;
 
-/**
- * Utility class for creating ProjectionAttribute instances.
- * Extracted from DefaultProjectionJoinAttribute and DefaultProjectionSchemaAttribute to eliminate code duplication.
- */
+/// Utility class for creating ProjectionAttribute instances.
+/// Extracted from DefaultProjectionJoinAttribute and DefaultProjectionSchemaAttribute to eliminate code duplication.
 public final class ProjectionAttributeFactory {
 
     private ProjectionAttributeFactory() {

--- a/nextentity-core/src/main/java/io/github/nextentity/jdbc/AbstractStatementBuilder.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/jdbc/AbstractStatementBuilder.java
@@ -452,8 +452,14 @@ public abstract class AbstractStatementBuilder {
         appendAttribute(attribute);
     }
 
+    /// 追加属性的 SQL 列引用。
+    ///
+    /// 对于根实体属性（deep == 1）和嵌入属性（{@code @Embedded}），使用主表别名；
+    /// 对于关联属性，使用对应的 JOIN 表别名。
+    ///
+    /// @param attribute 实体属性
     protected void appendAttribute(EntityAttribute attribute) {
-        if (attribute.deep() == 1) {
+        if (attribute.deep() == 1 || attribute.declareBy().isEmbedded()) {
             appendFromAlias().append(".");
         } else {
             MetamodelSchema<?> parent = attribute.declareBy();
@@ -534,11 +540,19 @@ public abstract class AbstractStatementBuilder {
         }
     }
 
+    /// 收集属性路径上需要的 JOIN 关联。
+    ///
+    /// 从属性的声明链底部向上遍历，将非嵌入的关联属性收集到待 JOIN 列表中。
+    /// 嵌入属性（{@code @Embedded}）共享同一张表，不需要 JOIN，直接跳过。
+    ///
+    /// @param attribute 要处理的属性
     protected void addJoin(MetamodelAttribute attribute) {
         ArrayDeque<JoinAttribute> joinAttributes = new ArrayDeque<>(attribute.deep());
         MetamodelSchema<?> join = attribute.declareBy();
         while (join instanceof JoinAttribute schemaAttribute) {
-            joinAttributes.addFirst(schemaAttribute);
+            if (!schemaAttribute.schema().isEmbedded()) {
+                joinAttributes.addFirst(schemaAttribute);
+            }
             join = schemaAttribute.declareBy();
         }
         for (JoinAttribute joinAttribute : joinAttributes) {

--- a/nextentity-core/src/main/java/io/github/nextentity/jdbc/AbstractStatementBuilder.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/jdbc/AbstractStatementBuilder.java
@@ -1,8 +1,8 @@
 package io.github.nextentity.jdbc;
 
 import io.github.nextentity.core.TypeCastUtil;
-import io.github.nextentity.core.constructor.SelectItem;
 import io.github.nextentity.core.constructor.QueryContext;
+import io.github.nextentity.core.constructor.SelectItem;
 import io.github.nextentity.core.expression.*;
 import io.github.nextentity.core.meta.*;
 import io.github.nextentity.core.meta.impl.IdentityValueConverter;
@@ -459,7 +459,7 @@ public abstract class AbstractStatementBuilder {
     ///
     /// @param attribute 实体属性
     protected void appendAttribute(EntityAttribute attribute) {
-        if (attribute.deep() == 1 || attribute.declareBy().isEmbedded()) {
+        if (attribute.deep() == 1 || attribute.declareBy() instanceof EmbeddedAttribute) {
             appendFromAlias().append(".");
         } else {
             MetamodelSchema<?> parent = attribute.declareBy();
@@ -550,9 +550,7 @@ public abstract class AbstractStatementBuilder {
         ArrayDeque<JoinAttribute> joinAttributes = new ArrayDeque<>(attribute.deep());
         MetamodelSchema<?> join = attribute.declareBy();
         while (join instanceof JoinAttribute schemaAttribute) {
-            if (!schemaAttribute.schema().isEmbedded()) {
-                joinAttributes.addFirst(schemaAttribute);
-            }
+            joinAttributes.addFirst(schemaAttribute);
             join = schemaAttribute.declareBy();
         }
         for (JoinAttribute joinAttribute : joinAttributes) {

--- a/nextentity-core/src/main/java/io/github/nextentity/jpa/JpaPersistExecutor.java
+++ b/nextentity-core/src/main/java/io/github/nextentity/jpa/JpaPersistExecutor.java
@@ -61,26 +61,26 @@ public class JpaPersistExecutor extends AbstractPersistExecutor {
             int attrCount = 0;
 
             for (var attr : attributes) {
-                String attrName = attr.name();
-                if (attrName.equals(idAttribute.name())) {
+                String attrName = jpqlAttributeName(attr);
+                if (attrName.equals(jpqlAttributeName(idAttribute))) {
                     continue;
                 }
                 if (attrCount > 0) {
                     jpql.append(", ");
                 }
                 jpql.append("e.").append(attrName).append(" = ?").append(paramIndex);
-                Object value = versionAttribute == attr ? getNextVersion(t, versionAttribute) : attr.get(t);
+                Object value = versionAttribute == attr ? getNextVersion(t, versionAttribute) : attr.getFromRoot(t);
                 params.add(value);
                 paramIndex++;
                 attrCount++;
             }
 
-            jpql.append(" WHERE e.").append(idAttribute.name()).append(" = ?").append(paramIndex);
+            jpql.append(" WHERE e.").append(jpqlAttributeName(idAttribute)).append(" = ?").append(paramIndex);
             params.add(id);
             paramIndex++;
 
             if (versionAttribute != null) {
-                jpql.append(" AND e.").append(versionAttribute.name()).append(" = ?").append(paramIndex);
+                jpql.append(" AND e.").append(jpqlAttributeName(versionAttribute)).append(" = ?").append(paramIndex);
                 params.add(version);
                 entityManager.detach(t);
             }
@@ -288,6 +288,17 @@ public class JpaPersistExecutor extends AbstractPersistExecutor {
 
     protected String getAttributeName(PathNode pathNode) {
         return pathNode.stream().collect(Collectors.joining("."));
+    }
+
+    /// 获取属性在 JPQL 中的路径名。
+    ///
+    /// 对于嵌套属性，路径段用点号连接（如 {@code address.street}），
+    /// 确保 JPQL 能正确导航到嵌入字段。
+    ///
+    /// @param attr 实体属性
+    /// @return JPQL 属性路径
+    private static String jpqlAttributeName(EntityAttribute attr) {
+        return attr.path().stream().collect(Collectors.joining("."));
     }
 
 }

--- a/nextentity-core/src/test/java/io/github/nextentity/core/constructor/EmbeddedEntityConstructorTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/core/constructor/EmbeddedEntityConstructorTest.java
@@ -1,0 +1,261 @@
+package io.github.nextentity.core.constructor;
+
+import io.github.nextentity.core.meta.EntityType;
+import io.github.nextentity.core.meta.ValueConverter;
+import io.github.nextentity.core.meta.impl.DefaultMetamodel;
+import io.github.nextentity.core.meta.impl.TestEntities;
+import io.github.nextentity.jdbc.Arguments;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 移植自 feature/embedded-support-d：EntityConstructorBuilder 对 {@code @Embedded} 属性的结果构造支持。
+ * <p>
+ * 目标：验证 EntityConstructorBuilder 能正确处理含嵌入属性的实体构造。
+ */
+@DisplayName("EntityConstructorBuilder - 嵌入属性结果构造")
+class EmbeddedEntityConstructorTest {
+
+    private DefaultMetamodel metamodel;
+
+    @BeforeEach
+    void setUp() {
+        metamodel = DefaultMetamodel.of();
+    }
+
+    @Nested
+    @DisplayName("基本嵌入构造")
+    class BasicEmbeddedConstructionTests {
+
+        @Test
+        @DisplayName("含嵌入属性的实体，构造器返回 ObjectConstructor")
+        void shouldBuildObjectConstructorForEmbeddedEntity() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+            EntityConstructorBuilder builder = new EntityConstructorBuilder(entityType, SchemaAttributePaths.empty());
+            ValueConstructor constructor = builder.build();
+
+            // 实体类不是接口也不是 Record → ObjectConstructor
+            assertThat(constructor).isInstanceOf(ObjectConstructor.class);
+        }
+
+        @Test
+        @DisplayName("build() 返回的构造器包含嵌入子属性对应的列")
+        void shouldBuildConstructorWithEmbeddedSubColumns() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+            EntityConstructorBuilder builder = new EntityConstructorBuilder(entityType, SchemaAttributePaths.empty());
+            ValueConstructor constructor = builder.build();
+
+            List<SelectItem> columns = constructor.columns();
+            // id, name, street, city, zipCode = 5 columns
+            assertThat(columns).hasSize(5);
+        }
+
+        @Test
+        @DisplayName("从 Arguments 构造嵌入对象")
+        void shouldConstructEmbeddedObjectFromArguments() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+            EntityConstructorBuilder builder = new EntityConstructorBuilder(entityType, SchemaAttributePaths.empty());
+            ValueConstructor constructor = builder.build();
+
+            Arguments args = new TestArguments(
+                    1L,          // id
+                    "John",      // name
+                    "5th Ave",   // street
+                    "NYC",       // city
+                    "10001"      // zipCode
+            );
+
+            Object result = constructor.construct(args);
+            assertThat(result).isInstanceOf(TestEntities.EntityWithEmbedded.class);
+
+            TestEntities.EntityWithEmbedded entity = (TestEntities.EntityWithEmbedded) result;
+            assertThat(entity.getId()).isEqualTo(1L);
+            assertThat(entity.getName()).isEqualTo("John");
+            assertThat(entity.getAddress()).isNotNull();
+            assertThat(entity.getAddress().getStreet()).isEqualTo("5th Ave");
+            assertThat(entity.getAddress().getCity()).isEqualTo("NYC");
+            assertThat(entity.getAddress().getZipCode()).isEqualTo("10001");
+        }
+
+        @Test
+        @DisplayName("所有嵌入子属性为 null 时嵌入对象为 null")
+        void shouldReturnNullEmbeddedWhenAllSubAttributesNull() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+            EntityConstructorBuilder builder = new EntityConstructorBuilder(entityType, SchemaAttributePaths.empty());
+            ValueConstructor constructor = builder.build();
+
+            Arguments args = new TestArguments(
+                    1L, "John", null, null, null
+            );
+
+            Object result = constructor.construct(args);
+            TestEntities.EntityWithEmbedded entity = (TestEntities.EntityWithEmbedded) result;
+            assertThat(entity.getAddress()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("嵌套嵌入构造")
+    class NestedEmbeddedConstructionTests {
+
+        @Test
+        @DisplayName("嵌套嵌入构造器包含所有子列")
+        void shouldNestedEmbeddedIncludeAllSubColumns() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedEmbedded.class);
+            EntityConstructorBuilder builder = new EntityConstructorBuilder(entityType, SchemaAttributePaths.empty());
+            ValueConstructor constructor = builder.build();
+
+            // id, contactInfo.email, contactInfo.phone,
+            // contactInfo.address.street, contactInfo.address.city, contactInfo.address.zipCode = 6 columns
+            List<SelectItem> columns = constructor.columns();
+            assertThat(columns).hasSize(6);
+        }
+
+        @Test
+        @DisplayName("从 Arguments 构造嵌套嵌入对象")
+        void shouldConstructNestedEmbeddedObjectFromArguments() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedEmbedded.class);
+            EntityConstructorBuilder builder = new EntityConstructorBuilder(entityType, SchemaAttributePaths.empty());
+            ValueConstructor constructor = builder.build();
+
+            Arguments args = new TestArguments(
+                    1L,          // id
+                    "a@b.com",   // email
+                    "123456",    // phone
+                    "5th Ave",   // street
+                    "NYC",       // city
+                    "10001"      // zipCode
+            );
+
+            Object result = constructor.construct(args);
+            assertThat(result).isInstanceOf(TestEntities.EntityWithNestedEmbedded.class);
+
+            TestEntities.EntityWithNestedEmbedded entity =
+                    (TestEntities.EntityWithNestedEmbedded) result;
+            assertThat(entity.getId()).isEqualTo(1L);
+            assertThat(entity.getContactInfo()).isNotNull();
+            assertThat(entity.getContactInfo().getEmail()).isEqualTo("a@b.com");
+            assertThat(entity.getContactInfo().getPhone()).isEqualTo("123456");
+            assertThat(entity.getContactInfo().getAddress()).isNotNull();
+            assertThat(entity.getContactInfo().getAddress().getStreet()).isEqualTo("5th Ave");
+            assertThat(entity.getContactInfo().getAddress().getCity()).isEqualTo("NYC");
+            assertThat(entity.getContactInfo().getAddress().getZipCode()).isEqualTo("10001");
+        }
+
+        @Test
+        @DisplayName("嵌套嵌入中间层为 null 时深层也为 null")
+        void shouldReturnNullNestedWhenMiddleNull() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedEmbedded.class);
+            EntityConstructorBuilder builder = new EntityConstructorBuilder(entityType, SchemaAttributePaths.empty());
+            ValueConstructor constructor = builder.build();
+
+            Arguments args = new TestArguments(
+                    1L, null, null, null, null, null
+            );
+
+            Object result = constructor.construct(args);
+            TestEntities.EntityWithNestedEmbedded entity =
+                    (TestEntities.EntityWithNestedEmbedded) result;
+            assertThat(entity.getContactInfo()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("错层嵌入构造")
+    class CrossLayerEmbeddedConstructionTests {
+
+        @Test
+        @DisplayName("错层嵌入构造器包含所有子列")
+        void shouldCrossLayerEmbeddedIncludeAllSubColumns() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithCrossLayerEmbedded.class);
+            EntityConstructorBuilder builder = new EntityConstructorBuilder(entityType, SchemaAttributePaths.empty());
+            ValueConstructor constructor = builder.build();
+
+            // id, address.city, address.zip.code, secondaryZip.code = 4 columns
+            List<SelectItem> columns = constructor.columns();
+            assertThat(columns).hasSize(4);
+        }
+
+        @Test
+        @DisplayName("从 Arguments 构造错层嵌套对象")
+        void shouldConstructCrossLayerEmbeddedObjectFromArguments() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithCrossLayerEmbedded.class);
+            EntityConstructorBuilder builder = new EntityConstructorBuilder(entityType, SchemaAttributePaths.empty());
+            ValueConstructor constructor = builder.build();
+
+            Arguments args = new TestArguments(
+                    1L,              // id
+                    "NYC",           // address.city
+                    "10001",         // address.zip.code
+                    "90210"          // secondaryZip.code
+            );
+
+            Object result = constructor.construct(args);
+            assertThat(result).isInstanceOf(TestEntities.EntityWithCrossLayerEmbedded.class);
+
+            TestEntities.EntityWithCrossLayerEmbedded entity =
+                    (TestEntities.EntityWithCrossLayerEmbedded) result;
+            assertThat(entity.getId()).isEqualTo(1L);
+            assertThat(entity.getAddress()).isNotNull();
+            assertThat(entity.getAddress().getCity()).isEqualTo("NYC");
+            assertThat(entity.getAddress().getZip()).isNotNull();
+            assertThat(entity.getAddress().getZip().getCode()).isEqualTo("10001");
+            assertThat(entity.getSecondaryZip()).isNotNull();
+            assertThat(entity.getSecondaryZip().getCode()).isEqualTo("90210");
+        }
+
+        @Test
+        @DisplayName("错层嵌入中层为 null 时深层也为 null，实体层级独立")
+        void shouldCrossLayerEmbeddedPartialNull() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithCrossLayerEmbedded.class);
+            EntityConstructorBuilder builder = new EntityConstructorBuilder(entityType, SchemaAttributePaths.empty());
+            ValueConstructor constructor = builder.build();
+
+            // 只有 id 和 secondaryZip 非空，address 全 null
+            Arguments args = new TestArguments(
+                    1L,           // id
+                    null,         // address.city
+                    null,         // address.zip.code
+                    "90210"       // secondaryZip.code
+            );
+
+            Object result = constructor.construct(args);
+            TestEntities.EntityWithCrossLayerEmbedded entity =
+                    (TestEntities.EntityWithCrossLayerEmbedded) result;
+            assertThat(entity.getAddress()).isNull();
+            assertThat(entity.getSecondaryZip()).isNotNull();
+            assertThat(entity.getSecondaryZip().getCode()).isEqualTo("90210");
+        }
+    }
+
+    /// 简单的测试用 Arguments 实现
+    static class TestArguments implements Arguments {
+        private final Object[] values;
+        private int index = 0;
+
+        TestArguments(Object... values) {
+            this.values = values;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Object get(int index, ValueConverter<?, ?> convertor) {
+            Object value = values[index];
+            if (convertor == null || value == null) {
+                return value;
+            }
+            return ((ValueConverter<Object, Object>) convertor).convertToEntityAttribute(value);
+        }
+
+        @Override
+        public Object next(ValueConverter<?, ?> convertor) {
+            return get(index++, convertor);
+        }
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/DefaultMetamodelTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/DefaultMetamodelTest.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -1406,6 +1407,96 @@ class DefaultMetamodelTest {
             assertThat(entityType.getPrimitives())
                     .noneMatch(a -> a.name().equals("contactInfo"))
                     .noneMatch(a -> a.name().equals("address"));
+        }
+
+        // ── 错层嵌套 @AttributeOverride 隔离测试 ──
+
+        @Test
+        @DisplayName("错层: address.city 覆盖生效")
+        void shouldCrossLayerCityOverride() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithCrossLayerOverride.class);
+
+            EntityBasicAttribute city = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("city"))
+                    .findFirst().orElse(null);
+            assertThat(city).isNotNull();
+            assertThat(city.columnName()).isEqualTo("addr_city");
+        }
+
+        @Test
+        @DisplayName("错层: address.zip.code 覆盖生效")
+        void shouldCrossLayerNestedZipCodeOverride() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithCrossLayerOverride.class);
+
+            EntityBasicAttribute code = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("code"))
+                    .findFirst().orElse(null);
+            assertThat(code).isNotNull();
+            assertThat(code.columnName()).isEqualTo("addr_zip_code");
+        }
+
+        @Test
+        @DisplayName("错层: secondaryZip.code 独立覆盖，不受 address 影响")
+        void shouldCrossLayerSecondaryZipBeIndependent() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithCrossLayerOverride.class);
+
+            // 有两个 name="code" 的 primitive（address.zip.code 和 secondaryZip.code）
+            // 其中一个应是 addr_zip_code（address.zip.code），另一个是 sec_zip_code（secondaryZip.code）
+            assertThat(entityType.getPrimitives())
+                    .filteredOn(a -> a.name().equals("code"))
+                    .hasSize(2)
+                    .extracting(a -> ((EntityBasicAttribute) a).columnName())
+                    .containsExactlyInAnyOrder("addr_zip_code", "sec_zip_code");
+        }
+
+        @Test
+        @DisplayName("错层: 无覆盖时默认列名")
+        void shouldCrossLayerNoOverrideReturnDefault() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithCrossLayerEmbedded.class);
+
+            EntityBasicAttribute city = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("city"))
+                    .findFirst().orElse(null);
+            assertThat(city).isNotNull();
+            assertThat(city.columnName()).isEqualTo("city");
+
+            EntityBasicAttribute code = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("code"))
+                    .findFirst().orElse(null);
+            assertThat(code).isNotNull();
+            assertThat(code.columnName()).isEqualTo("code");
+        }
+
+        // ── Resolver 直接测试 ──
+
+        @Test
+        @DisplayName("resolver: 有 @AttributeOverride 时返回覆盖映射")
+        void shouldResolverReturnOverrides() {
+            DefaultMetamodelResolver resolver = DefaultMetamodelResolver.of();
+            var accessors = io.github.nextentity.core.reflect.schema.impl.DefaultAccessor
+                    .of(TestEntities.EntityWithAttributeOverride.class);
+            var fullNameAccessor = accessors.stream()
+                    .filter(a -> a.name().equals("fullName"))
+                    .findFirst().orElseThrow();
+
+            Map<String, String> overrides = resolver.getAttributeOverrides(fullNameAccessor);
+
+            assertThat(overrides).containsEntry("firstName", "first_name_ov");
+        }
+
+        @Test
+        @DisplayName("resolver: 无 @AttributeOverride 时返回空映射")
+        void shouldResolverReturnEmptyWhenNoOverride() {
+            DefaultMetamodelResolver resolver = DefaultMetamodelResolver.of();
+            var accessors = io.github.nextentity.core.reflect.schema.impl.DefaultAccessor
+                    .of(TestEntities.EntityWithEmbedded.class);
+            var addressAccessor = accessors.stream()
+                    .filter(a -> a.name().equals("address"))
+                    .findFirst().orElseThrow();
+
+            Map<String, String> overrides = resolver.getAttributeOverrides(addressAccessor);
+
+            assertThat(overrides).isEmpty();
         }
     }
 

--- a/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/DefaultMetamodelTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/DefaultMetamodelTest.java
@@ -1242,7 +1242,6 @@ class DefaultMetamodelTest {
                     .filter(a -> a.name().equals("firstName"))
                     .findFirst().orElse(null);
             assertThat(firstName).isNotNull();
-            // 当前缺陷: @AttributeOverride 未处理，列名仍为默认的 "first_name"
             assertThat(firstName.columnName()).isEqualTo("first_name_ov");
         }
 
@@ -1267,14 +1266,12 @@ class DefaultMetamodelTest {
                     .filter(a -> a.name().equals("street"))
                     .findFirst().orElse(null);
             assertThat(street).isNotNull();
-            // 当前缺陷: @AttributeOverrides 未处理，列名仍为默认的 "street"
             assertThat(street.columnName()).isEqualTo("addr_street");
 
             EntityBasicAttribute city = (EntityBasicAttribute) entityType.getPrimitives().stream()
                     .filter(a -> a.name().equals("city"))
                     .findFirst().orElse(null);
             assertThat(city).isNotNull();
-            // 当前缺陷: @AttributeOverrides 未处理，列名仍为默认的 "city"
             assertThat(city.columnName()).isEqualTo("addr_city");
         }
 
@@ -1351,7 +1348,6 @@ class DefaultMetamodelTest {
                     .filter(a -> a.name().equals("email"))
                     .findFirst().orElse(null);
             assertThat(email).isNotNull();
-            // 当前缺陷: 多层嵌套 @AttributeOverride 未处理，列名仍为默认的 "email"
             assertThat(email.columnName()).isEqualTo("contact_email");
         }
 
@@ -1365,7 +1361,6 @@ class DefaultMetamodelTest {
                     .filter(a -> a.name().equals("street"))
                     .findFirst().orElse(null);
             assertThat(street).isNotNull();
-            // 当前缺陷: 多层嵌套 @AttributeOverride 未处理，列名仍为默认的 "street"
             assertThat(street.columnName()).isEqualTo("deep_street");
         }
 

--- a/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/DefaultMetamodelTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/DefaultMetamodelTest.java
@@ -3,6 +3,8 @@ package io.github.nextentity.core.meta.impl;
 import io.github.nextentity.core.exception.ConfigurationException;
 import io.github.nextentity.core.converter.InstantConverter;
 import io.github.nextentity.core.meta.*;
+import io.github.nextentity.core.reflect.schema.Accessor;
+import io.github.nextentity.core.reflect.schema.impl.DefaultAccessor;
 import jakarta.persistence.FetchType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -1151,7 +1153,77 @@ class DefaultMetamodelTest {
         }
     }
 
-    // ── 边界情况测试 ──
+    @Nested
+    @DisplayName("嵌入属性")
+    class EmbeddedAttributeTests {
+
+        @Test
+        @DisplayName("DefaultMetamodelResolver 能检测到 @Embedded 注解")
+        void shouldResolverDetectEmbeddedAnnotation() {
+            DefaultMetamodelResolver resolver = DefaultMetamodelResolver.of();
+            var accessors = DefaultAccessor.of(TestEntities.EntityWithEmbedded.class);
+            Accessor addressAccessor = accessors.stream()
+                    .filter(a -> a.name().equals("address"))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(resolver.isEmbedded(addressAccessor)).isTrue();
+        }
+
+        @Test
+        @DisplayName("@Embedded 字段应被解析为 EntitySchemaAttribute")
+        void shouldEmbeddedFieldBeResolvedAsSchemaAttribute() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+            EntityAttribute addressAttr = entityType.getAttribute("address");
+
+            assertThat(addressAttr).isInstanceOf(EntitySchemaAttribute.class);
+        }
+
+        @Test
+        @DisplayName("@Embedded 字段的 isEmbedded() 应返回 true")
+        void shouldEmbeddedFieldIsEmbeddedReturnTrue() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+            EntityAttribute addressAttr = entityType.getAttribute("address");
+
+            assertThat(addressAttr).isInstanceOf(MetamodelSchema.class);
+            assertThat(((MetamodelSchema<?>) addressAttr).isEmbedded()).isTrue();
+        }
+
+        @Test
+        @DisplayName("@Embedded 字段的内部子属性应被展开到 getPrimitives")
+        void shouldExpandEmbeddedFieldInnerAttributesToPrimitives() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+
+            assertThat(entityType.getPrimitives())
+                    .anyMatch(a -> a.name().equals("street"))
+                    .anyMatch(a -> a.name().equals("city"))
+                    .anyMatch(a -> a.name().equals("zipCode"));
+        }
+
+        @Test
+        @DisplayName("@Embedded 字段自身不应作为整体出现在 getPrimitives 中")
+        void shouldEmbeddedFieldItselfNotAppearInPrimitives() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+
+            assertThat(entityType.getPrimitives())
+                    .noneMatch(a -> a.name().equals("address"));
+        }
+
+        @Test
+        @DisplayName("嵌套 @Embedded 字段应递归展开内部子属性到 getPrimitives")
+        void shouldNestedEmbeddedFieldExpandRecursively() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedEmbedded.class);
+
+            assertThat(entityType.getPrimitives())
+                    .anyMatch(a -> a.name().equals("email"))
+                    .anyMatch(a -> a.name().equals("phone"))
+                    .anyMatch(a -> a.name().equals("street"))
+                    .anyMatch(a -> a.name().equals("city"))
+                    .anyMatch(a -> a.name().equals("zipCode"))
+                    .noneMatch(a -> a.name().equals("contactInfo"))
+                    .noneMatch(a -> a.name().equals("address"));
+        }
+    }
 
     @Nested
     @DisplayName("边界情况")

--- a/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/DefaultMetamodelTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/DefaultMetamodelTest.java
@@ -1225,6 +1225,190 @@ class DefaultMetamodelTest {
         }
     }
 
+    // ── @AttributeOverride / @AttributeOverrides 测试 ──
+
+    @Nested
+    @DisplayName("@AttributeOverride / @AttributeOverrides")
+    class AttributeOverrideTests {
+
+        @Test
+        @DisplayName("@AttributeOverride 覆盖嵌入字段的列名")
+        void shouldAttributeOverrideChangeColumnNameOfEmbeddedField() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverride.class);
+
+            // 嵌入子属性通过 getPrimitives() 获取
+            EntityBasicAttribute firstName = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("firstName"))
+                    .findFirst().orElse(null);
+            assertThat(firstName).isNotNull();
+            // 当前缺陷: @AttributeOverride 未处理，列名仍为默认的 "first_name"
+            assertThat(firstName.columnName()).isEqualTo("first_name_ov");
+        }
+
+        @Test
+        @DisplayName("@AttributeOverride 未覆盖的嵌入字段保持默认列名")
+        void shouldNonOverriddenFieldKeepDefaultColumnName() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverride.class);
+
+            EntityBasicAttribute lastName = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("lastName"))
+                    .findFirst().orElse(null);
+            assertThat(lastName).isNotNull();
+            assertThat(lastName.columnName()).isEqualTo("last_name");
+        }
+
+        @Test
+        @DisplayName("@AttributeOverrides 覆盖多个嵌入字段的列名")
+        void shouldAttributeOverridesChangeMultipleColumnNames() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverrides.class);
+
+            EntityBasicAttribute street = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("street"))
+                    .findFirst().orElse(null);
+            assertThat(street).isNotNull();
+            // 当前缺陷: @AttributeOverrides 未处理，列名仍为默认的 "street"
+            assertThat(street.columnName()).isEqualTo("addr_street");
+
+            EntityBasicAttribute city = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("city"))
+                    .findFirst().orElse(null);
+            assertThat(city).isNotNull();
+            // 当前缺陷: @AttributeOverrides 未处理，列名仍为默认的 "city"
+            assertThat(city.columnName()).isEqualTo("addr_city");
+        }
+
+        @Test
+        @DisplayName("@AttributeOverrides 未覆盖的字段保持默认列名")
+        void shouldNonOverriddenFieldKeepDefaultColumnNameInOverridesEntity() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverrides.class);
+
+            EntityBasicAttribute zipCode = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("zipCode"))
+                    .findFirst().orElse(null);
+            assertThat(zipCode).isNotNull();
+            assertThat(zipCode.columnName()).isEqualTo("zip_code");
+        }
+
+        @Test
+        @DisplayName("@AttributeOverride 嵌入字段出现在 getPrimitives 中")
+        void shouldOverriddenEmbeddedFieldsAppearInPrimitives() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverride.class);
+
+            assertThat(entityType.getPrimitives())
+                    .anyMatch(a -> a.name().equals("firstName"))
+                    .anyMatch(a -> a.name().equals("lastName"));
+            assertThat(entityType.getPrimitives())
+                    .noneMatch(a -> a.name().equals("fullName"));
+        }
+
+        @Test
+        @DisplayName("@AttributeOverrides 嵌入字段出现在 getPrimitives 中")
+        void shouldAttributeOverridesEmbeddedFieldsAppearInPrimitives() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverrides.class);
+
+            assertThat(entityType.getPrimitives())
+                    .anyMatch(a -> a.name().equals("street"))
+                    .anyMatch(a -> a.name().equals("city"))
+                    .anyMatch(a -> a.name().equals("zipCode"));
+            assertThat(entityType.getPrimitives())
+                    .noneMatch(a -> a.name().equals("address"));
+        }
+
+        @Test
+        @DisplayName("@AttributeOverride 嵌入属性也有正确的 getAttribute(name)")
+        void shouldOverriddenEmbeddedFieldResolvedByGetAttribute() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverride.class);
+
+            EntityAttribute fullName = entityType.getAttribute("fullName");
+            assertThat(fullName).isInstanceOf(EntitySchemaAttribute.class);
+            assertThat(((MetamodelSchema<?>) fullName).isEmbedded()).isTrue();
+        }
+
+        @Test
+        @DisplayName("嵌入子属性（非 id 字段）不是 id 也不是 version")
+        void shouldEmbeddedFieldPrimitivesNotBeIdOrVersion() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverride.class);
+
+            assertThat(entityType.getPrimitives())
+                    .filteredOn(a -> !a.name().equals("id") && !a.name().equals("name"))
+                    .allSatisfy(a -> {
+                        EntityBasicAttribute basic = (EntityBasicAttribute) a;
+                        assertThat(basic.isId()).isFalse();
+                        assertThat(basic.isVersion()).isFalse();
+                    });
+        }
+
+        // ── 多层嵌套 @AttributeOverride 测试 ──
+
+        @Test
+        @DisplayName("多层嵌套: 一层深度 @AttributeOverride(email) 覆盖列名")
+        void shouldNestedAttributeOverrideOneLevelDeep() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedAttributeOverride.class);
+
+            // email 在 ContactInfo 中，被 @AttributeOverride(name="email", column=@Column(name="contact_email")) 覆盖
+            EntityBasicAttribute email = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("email"))
+                    .findFirst().orElse(null);
+            assertThat(email).isNotNull();
+            // 当前缺陷: 多层嵌套 @AttributeOverride 未处理，列名仍为默认的 "email"
+            assertThat(email.columnName()).isEqualTo("contact_email");
+        }
+
+        @Test
+        @DisplayName("多层嵌套: 两层深度 @AttributeOverride(address.street) 覆盖列名")
+        void shouldNestedAttributeOverrideTwoLevelsDeep() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedAttributeOverride.class);
+
+            // street 在 ContactInfo.address 中，被 @AttributeOverride(name="address.street", column=@Column(name="deep_street")) 覆盖
+            EntityBasicAttribute street = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("street"))
+                    .findFirst().orElse(null);
+            assertThat(street).isNotNull();
+            // 当前缺陷: 多层嵌套 @AttributeOverride 未处理，列名仍为默认的 "street"
+            assertThat(street.columnName()).isEqualTo("deep_street");
+        }
+
+        @Test
+        @DisplayName("多层嵌套: 未覆盖字段保持默认列名")
+        void shouldNestedAttributeOverrideKeepDefaultForNonOverridden() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedAttributeOverride.class);
+
+            EntityBasicAttribute phone = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("phone"))
+                    .findFirst().orElse(null);
+            assertThat(phone).isNotNull();
+            assertThat(phone.columnName()).isEqualTo("phone");
+
+            EntityBasicAttribute city = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("city"))
+                    .findFirst().orElse(null);
+            assertThat(city).isNotNull();
+            assertThat(city.columnName()).isEqualTo("city");
+
+            EntityBasicAttribute zipCode = (EntityBasicAttribute) entityType.getPrimitives().stream()
+                    .filter(a -> a.name().equals("zipCode"))
+                    .findFirst().orElse(null);
+            assertThat(zipCode).isNotNull();
+            assertThat(zipCode.columnName()).isEqualTo("zip_code");
+        }
+
+        @Test
+        @DisplayName("多层嵌套: 嵌入字段展开到 getPrimitives 中")
+        void shouldNestedAttributeOverrideExpandPrimitives() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedAttributeOverride.class);
+
+            assertThat(entityType.getPrimitives())
+                    .anyMatch(a -> a.name().equals("email"))
+                    .anyMatch(a -> a.name().equals("phone"))
+                    .anyMatch(a -> a.name().equals("street"))
+                    .anyMatch(a -> a.name().equals("city"))
+                    .anyMatch(a -> a.name().equals("zipCode"));
+            assertThat(entityType.getPrimitives())
+                    .noneMatch(a -> a.name().equals("contactInfo"))
+                    .noneMatch(a -> a.name().equals("address"));
+        }
+    }
+
     @Nested
     @DisplayName("边界情况")
     class EdgeCaseTests {

--- a/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/DefaultMetamodelTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/DefaultMetamodelTest.java
@@ -1,7 +1,7 @@
 package io.github.nextentity.core.meta.impl;
 
-import io.github.nextentity.core.exception.ConfigurationException;
 import io.github.nextentity.core.converter.InstantConverter;
+import io.github.nextentity.core.exception.ConfigurationException;
 import io.github.nextentity.core.meta.*;
 import io.github.nextentity.core.reflect.schema.Accessor;
 import io.github.nextentity.core.reflect.schema.impl.DefaultAccessor;
@@ -11,18 +11,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1177,7 +1169,7 @@ class DefaultMetamodelTest {
             EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
             EntityAttribute addressAttr = entityType.getAttribute("address");
 
-            assertThat(addressAttr).isInstanceOf(EntitySchemaAttribute.class);
+            assertThat(addressAttr).isInstanceOf(EmbeddedAttribute.class);
         }
 
         @Test
@@ -1187,7 +1179,7 @@ class DefaultMetamodelTest {
             EntityAttribute addressAttr = entityType.getAttribute("address");
 
             assertThat(addressAttr).isInstanceOf(MetamodelSchema.class);
-            assertThat(((MetamodelSchema<?>) addressAttr).isEmbedded()).isTrue();
+            assertThat(addressAttr).isInstanceOf(EmbeddedAttribute.class);
         }
 
         @Test
@@ -1215,7 +1207,8 @@ class DefaultMetamodelTest {
         void shouldNestedEmbeddedFieldExpandRecursively() {
             EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedEmbedded.class);
 
-            assertThat(entityType.getPrimitives())
+            var primitives = entityType.getPrimitives();
+            assertThat(primitives)
                     .anyMatch(a -> a.name().equals("email"))
                     .anyMatch(a -> a.name().equals("phone"))
                     .anyMatch(a -> a.name().equals("street"))
@@ -1318,8 +1311,8 @@ class DefaultMetamodelTest {
             EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverride.class);
 
             EntityAttribute fullName = entityType.getAttribute("fullName");
-            assertThat(fullName).isInstanceOf(EntitySchemaAttribute.class);
-            assertThat(((MetamodelSchema<?>) fullName).isEmbedded()).isTrue();
+            assertThat(fullName).isInstanceOf(EmbeddedAttribute.class);
+            assertThat(fullName).isInstanceOf(EmbeddedAttribute.class);
         }
 
         @Test

--- a/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/TestEntities.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/TestEntities.java
@@ -453,5 +453,69 @@ public class TestEntities {
         public void setInstant(Instant instant) { this.instant = instant; }
     }
 
+    public static class Address {
+        private String street;
+        private String city;
+        private String zipCode;
+
+        public Address() {}
+
+        public String getStreet() { return street; }
+        public void setStreet(String street) { this.street = street; }
+        public String getCity() { return city; }
+        public void setCity(String city) { this.city = city; }
+        public String getZipCode() { return zipCode; }
+        public void setZipCode(String zipCode) { this.zipCode = zipCode; }
+    }
+
+    @jakarta.persistence.Entity
+    public static class EntityWithEmbedded {
+        @Id
+        private Long id;
+        private String name;
+        @jakarta.persistence.Embedded
+        private Address address;
+
+        public EntityWithEmbedded() {}
+
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public Address getAddress() { return address; }
+        public void setAddress(Address address) { this.address = address; }
+    }
+
+    public static class ContactInfo {
+        private String email;
+        private String phone;
+        @jakarta.persistence.Embedded
+        private Address address;
+
+        public ContactInfo() {}
+
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email; }
+        public String getPhone() { return phone; }
+        public void setPhone(String phone) { this.phone = phone; }
+        public Address getAddress() { return address; }
+        public void setAddress(Address address) { this.address = address; }
+    }
+
+    @jakarta.persistence.Entity
+    public static class EntityWithNestedEmbedded {
+        @Id
+        private Long id;
+        @jakarta.persistence.Embedded
+        private ContactInfo contactInfo;
+
+        public EntityWithNestedEmbedded() {}
+
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+        public ContactInfo getContactInfo() { return contactInfo; }
+        public void setContactInfo(ContactInfo contactInfo) { this.contactInfo = contactInfo; }
+    }
+
     private TestEntities() {}
 }

--- a/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/TestEntities.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/TestEntities.java
@@ -1,6 +1,8 @@
 package io.github.nextentity.core.meta.impl;
 
 import io.github.nextentity.core.annotation.Fetch;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -468,6 +470,18 @@ public class TestEntities {
         public void setZipCode(String zipCode) { this.zipCode = zipCode; }
     }
 
+    public static class FullName {
+        private String firstName;
+        private String lastName;
+
+        public FullName() {}
+
+        public String getFirstName() { return firstName; }
+        public void setFirstName(String firstName) { this.firstName = firstName; }
+        public String getLastName() { return lastName; }
+        public void setLastName(String lastName) { this.lastName = lastName; }
+    }
+
     @jakarta.persistence.Entity
     public static class EntityWithEmbedded {
         @Id
@@ -515,6 +529,63 @@ public class TestEntities {
         public void setId(Long id) { this.id = id; }
         public ContactInfo getContactInfo() { return contactInfo; }
         public void setContactInfo(ContactInfo contactInfo) { this.contactInfo = contactInfo; }
+    }
+
+    @jakarta.persistence.Entity
+    public static class EntityWithNestedAttributeOverride {
+        @Id
+        private Long id;
+        @jakarta.persistence.Embedded
+        @AttributeOverrides({
+                @AttributeOverride(name = "email", column = @Column(name = "contact_email")),
+                @AttributeOverride(name = "address.street", column = @Column(name = "deep_street"))
+        })
+        private ContactInfo contactInfo;
+
+        public EntityWithNestedAttributeOverride() {}
+
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+        public ContactInfo getContactInfo() { return contactInfo; }
+        public void setContactInfo(ContactInfo contactInfo) { this.contactInfo = contactInfo; }
+    }
+
+    @jakarta.persistence.Entity
+    public static class EntityWithAttributeOverride {
+        @Id
+        private Long id;
+        private String name;
+        @jakarta.persistence.Embedded
+        @AttributeOverride(name = "firstName", column = @Column(name = "first_name_ov"))
+        private FullName fullName;
+
+        public EntityWithAttributeOverride() {}
+
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public FullName getFullName() { return fullName; }
+        public void setFullName(FullName fullName) { this.fullName = fullName; }
+    }
+
+    @jakarta.persistence.Entity
+    public static class EntityWithAttributeOverrides {
+        @Id
+        private Long id;
+        @jakarta.persistence.Embedded
+        @AttributeOverrides({
+                @AttributeOverride(name = "street", column = @Column(name = "addr_street")),
+                @AttributeOverride(name = "city", column = @Column(name = "addr_city"))
+        })
+        private Address address;
+
+        public EntityWithAttributeOverrides() {}
+
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+        public Address getAddress() { return address; }
+        public void setAddress(Address address) { this.address = address; }
     }
 
     private TestEntities() {}

--- a/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/TestEntities.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/core/meta/impl/TestEntities.java
@@ -588,5 +588,70 @@ public class TestEntities {
         public void setAddress(Address address) { this.address = address; }
     }
 
+    // ── 错层嵌套测试用 ──
+
+    public static class ZipCode {
+        private String code;
+
+        public ZipCode() {}
+
+        public String getCode() { return code; }
+        public void setCode(String code) { this.code = code; }
+    }
+
+    public static class AddressWithZip {
+        private String city;
+        @jakarta.persistence.Embedded
+        private ZipCode zip;
+
+        public AddressWithZip() {}
+
+        public String getCity() { return city; }
+        public void setCity(String city) { this.city = city; }
+        public ZipCode getZip() { return zip; }
+        public void setZip(ZipCode zip) { this.zip = zip; }
+    }
+
+    @jakarta.persistence.Entity
+    public static class EntityWithCrossLayerEmbedded {
+        @Id
+        private Long id;
+        @jakarta.persistence.Embedded
+        private AddressWithZip address;
+        @jakarta.persistence.Embedded
+        private ZipCode secondaryZip;
+
+        public EntityWithCrossLayerEmbedded() {}
+
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+        public AddressWithZip getAddress() { return address; }
+        public void setAddress(AddressWithZip address) { this.address = address; }
+        public ZipCode getSecondaryZip() { return secondaryZip; }
+        public void setSecondaryZip(ZipCode secondaryZip) { this.secondaryZip = secondaryZip; }
+    }
+
+    @jakarta.persistence.Entity
+    public static class EntityWithCrossLayerOverride {
+        @Id
+        private Long id;
+        @jakarta.persistence.Embedded
+        @AttributeOverride(name = "city", column = @Column(name = "addr_city"))
+        @AttributeOverride(name = "zip.code", column = @Column(name = "addr_zip_code"))
+        private AddressWithZip address;
+        @jakarta.persistence.Embedded
+        @AttributeOverride(name = "code", column = @Column(name = "sec_zip_code"))
+        private ZipCode secondaryZip;
+
+        public EntityWithCrossLayerOverride() {}
+
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+        public AddressWithZip getAddress() { return address; }
+        public void setAddress(AddressWithZip address) { this.address = address; }
+        public ZipCode getSecondaryZip() { return secondaryZip; }
+        public void setSecondaryZip(ZipCode secondaryZip) { this.secondaryZip = secondaryZip; }
+    }
+
     private TestEntities() {}
 }

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/AttributeOverrideCrudIntegrationTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/AttributeOverrideCrudIntegrationTest.java
@@ -1,0 +1,191 @@
+package io.github.nextentity.integration;
+
+import io.github.nextentity.integration.config.IntegrationTestContext;
+import io.github.nextentity.integration.config.IntegrationTestProvider;
+import io.github.nextentity.integration.entity.Address;
+import io.github.nextentity.integration.entity.ContactInfo;
+import io.github.nextentity.integration.entity.PersonWithNestedOverriddenContact;
+import io.github.nextentity.integration.entity.PersonWithOverriddenAddress;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("@AttributeOverride CRUD Integration Tests")
+public class AttributeOverrideCrudIntegrationTest {
+
+    @AfterEach
+    void tearDown() {
+        var context = IntegrationTestProvider.getEntityManagerContext();
+        if (context != null) {
+            context.reset();
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Create: person with @AttributeOverridden address columns")
+    void shouldCreatePersonWithOverriddenAddress(IntegrationTestContext context) {
+        Address address = new Address("1st Ave", "Springfield", "12345");
+        PersonWithOverriddenAddress person = new PersonWithOverriddenAddress(100L, "John", address);
+
+        context.getUpdateExecutor().insert(person, context.getEntityContext(PersonWithOverriddenAddress.class));
+
+        PersonWithOverriddenAddress found = context.queryPersonWithOverriddenAddresses()
+                .where(PersonWithOverriddenAddress::getId).eq(100L)
+                .first();
+        assertThat(found).isNotNull();
+        assertThat(found.getName()).isEqualTo("John");
+        assertThat(found.getAddress()).isNotNull();
+        assertThat(found.getAddress().getStreet()).isEqualTo("1st Ave");
+        assertThat(found.getAddress().getCity()).isEqualTo("Springfield");
+        assertThat(found.getAddress().getZipCode()).isEqualTo("12345");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Create: person with nested @AttributeOverridden contact columns")
+    void shouldCreatePersonWithNestedOverriddenContact(IntegrationTestContext context) {
+        Address addr = new Address("5th Ave", "Metropolis", "67890");
+        ContactInfo contact = new ContactInfo("john@test.com", "555-0100", addr);
+        PersonWithNestedOverriddenContact person = new PersonWithNestedOverriddenContact(200L, "Jane", contact);
+
+        context.getUpdateExecutor().insert(person, context.getEntityContext(PersonWithNestedOverriddenContact.class));
+
+        PersonWithNestedOverriddenContact found = context.queryPersonWithNestedOverriddenContacts()
+                .where(PersonWithNestedOverriddenContact::getId).eq(200L)
+                .first();
+        assertThat(found).isNotNull();
+        assertThat(found.getContactInfo().getEmail()).isEqualTo("john@test.com");
+        assertThat(found.getContactInfo().getPhone()).isEqualTo("555-0100");
+        assertThat(found.getContactInfo().getAddress().getStreet()).isEqualTo("5th Ave");
+        assertThat(found.getContactInfo().getAddress().getCity()).isEqualTo("Metropolis");
+        assertThat(found.getContactInfo().getAddress().getZipCode()).isEqualTo("67890");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Batch insert with @AttributeOverridden address")
+    void shouldBatchCreateWithOverriddenAddress(IntegrationTestContext context) {
+        PersonWithOverriddenAddress p1 = new PersonWithOverriddenAddress(110L, "Alice",
+                new Address("Elm St", "Gotham", "11111"));
+        PersonWithOverriddenAddress p2 = new PersonWithOverriddenAddress(111L, "Bob",
+                new Address("Oak Ave", "Star City", "22222"));
+
+        context.getUpdateExecutor().insertAll(List.of(p1, p2),
+                context.getEntityContext(PersonWithOverriddenAddress.class));
+
+        List<PersonWithOverriddenAddress> all = context.queryPersonWithOverriddenAddresses()
+                .where(PersonWithOverriddenAddress::getId).in(110L, 111L)
+                .orderBy(PersonWithOverriddenAddress::getId).asc()
+                .list();
+        assertThat(all).hasSize(2);
+        assertThat(all.get(0).getAddress().getStreet()).isEqualTo("Elm St");
+        assertThat(all.get(1).getAddress().getStreet()).isEqualTo("Oak Ave");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Filter by overridden field via path chain")
+    void shouldFilterByOverriddenFieldViaPathChain(IntegrationTestContext context) {
+        PersonWithOverriddenAddress p1 = new PersonWithOverriddenAddress(120L, "U1",
+                new Address("Broadway", "NYC", "001"));
+        PersonWithOverriddenAddress p2 = new PersonWithOverriddenAddress(121L, "U2",
+                new Address("5th Ave", "NYC", "002"));
+
+        context.getUpdateExecutor().insertAll(List.of(p1, p2),
+                context.getEntityContext(PersonWithOverriddenAddress.class));
+
+        List<PersonWithOverriddenAddress> result = context.queryPersonWithOverriddenAddresses()
+                .where(PersonWithOverriddenAddress::getAddress).get(Address::getStreet).eq("Broadway")
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getAddress().getStreet()).isEqualTo("Broadway");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Filter by nested overridden field (ContactInfo.Address.street)")
+    void shouldFilterByNestedOverriddenField(IntegrationTestContext context) {
+        PersonWithNestedOverriddenContact p1 = new PersonWithNestedOverriddenContact(130L, "NU1",
+                new ContactInfo("a@x.com", "111", new Address("Pine St", "Gotham", "000")));
+        PersonWithNestedOverriddenContact p2 = new PersonWithNestedOverriddenContact(131L, "NU2",
+                new ContactInfo("b@x.com", "222", new Address("Cedar Ave", "Star City", "000")));
+
+        context.getUpdateExecutor().insertAll(List.of(p1, p2),
+                context.getEntityContext(PersonWithNestedOverriddenContact.class));
+
+        List<PersonWithNestedOverriddenContact> result = context.queryPersonWithNestedOverriddenContacts()
+                .where(PersonWithNestedOverriddenContact::getContactInfo).get(ContactInfo::getAddress).get(Address::getCity).eq("Gotham")
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getContactInfo().getAddress().getCity()).isEqualTo("Gotham");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Update overridden embedded fields")
+    void shouldUpdateOverriddenEmbeddedFields(IntegrationTestContext context) {
+        context.getUpdateExecutor().insert(
+                new PersonWithOverriddenAddress(140L, "Batman",
+                        new Address("Old St", "OldCity", "00000")),
+                context.getEntityContext(PersonWithOverriddenAddress.class));
+
+        PersonWithOverriddenAddress toUpdate = context.queryPersonWithOverriddenAddresses()
+                .where(PersonWithOverriddenAddress::getId).eq(140L).first();
+        toUpdate.getAddress().setStreet("New St");
+        toUpdate.getAddress().setCity("NewCity");
+        context.getUpdateExecutor().update(toUpdate, context.getEntityContext(PersonWithOverriddenAddress.class));
+
+        PersonWithOverriddenAddress updated = context.queryPersonWithOverriddenAddresses()
+                .where(PersonWithOverriddenAddress::getId).eq(140L).first();
+        assertThat(updated.getAddress().getStreet()).isEqualTo("New St");
+        assertThat(updated.getAddress().getCity()).isEqualTo("NewCity");
+        assertThat(updated.getAddress().getZipCode()).isEqualTo("00000");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Update nested overridden fields (ContactInfo.email + Address.street)")
+    void shouldUpdateNestedOverriddenFields(IntegrationTestContext context) {
+        context.getUpdateExecutor().insert(
+                new PersonWithNestedOverriddenContact(150L, "Nested Update",
+                        new ContactInfo("old@test.com", "555-0000",
+                                new Address("Old Rd", "OldCity", "77777"))),
+                context.getEntityContext(PersonWithNestedOverriddenContact.class));
+
+        PersonWithNestedOverriddenContact toUpdate = context.queryPersonWithNestedOverriddenContacts()
+                .where(PersonWithNestedOverriddenContact::getId).eq(150L).first();
+        toUpdate.getContactInfo().setEmail("new@test.com");
+        toUpdate.getContactInfo().getAddress().setStreet("New Rd");
+        context.getUpdateExecutor().update(toUpdate, context.getEntityContext(PersonWithNestedOverriddenContact.class));
+
+        PersonWithNestedOverriddenContact updated = context.queryPersonWithNestedOverriddenContacts()
+                .where(PersonWithNestedOverriddenContact::getId).eq(150L).first();
+        assertThat(updated.getContactInfo().getEmail()).isEqualTo("new@test.com");
+        assertThat(updated.getContactInfo().getAddress().getStreet()).isEqualTo("New Rd");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Delete person with @AttributeOverridden address")
+    void shouldDeleteWithOverriddenAddress(IntegrationTestContext context) {
+        context.getUpdateExecutor().insert(
+                new PersonWithOverriddenAddress(160L, "Delete Me",
+                        new Address("Cedar Ln", "Star City", "33333")),
+                context.getEntityContext(PersonWithOverriddenAddress.class));
+
+        PersonWithOverriddenAddress toDelete = context.queryPersonWithOverriddenAddresses()
+                .where(PersonWithOverriddenAddress::getId).eq(160L).first();
+        assertThat(toDelete).isNotNull();
+
+        context.getUpdateExecutor().delete(toDelete, context.getEntityContext(PersonWithOverriddenAddress.class));
+
+        assertThat(context.queryPersonWithOverriddenAddresses()
+                .where(PersonWithOverriddenAddress::getId).eq(160L).first()).isNull();
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/EmbeddedCrudIntegrationTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/EmbeddedCrudIntegrationTest.java
@@ -239,4 +239,201 @@ public class EmbeddedCrudIntegrationTest {
         assertThat(result.get(0).getName()).isEqualTo("Updated Name");
         assertThat(result.get(0).getAddress().getCity()).isEqualTo("New York");
     }
+
+    // ── 非 id 字段条件查询 ──
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should query by name condition")
+    void shouldQueryByName(IntegrationTestContext context) {
+        context.getUpdateExecutor().insert(
+                TestDataFactory.createPersonWithAddress(600L, "Alice", new Address("1st St", "Springfield", "11111")),
+                context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getName).eq("Alice")
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(600L);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should query by name like")
+    void shouldQueryByNameLike(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                TestDataFactory.createPersonWithAddress(601L, "Alice", new Address("Oak St", "Portland", "97201")),
+                TestDataFactory.createPersonWithAddress(602L, "Albert", new Address("Pine St", "Seattle", "98101")),
+                TestDataFactory.createPersonWithAddress(603L, "Bob", new Address("Elm St", "Denver", "80201"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getName).like("Al%")
+                .orderBy(PersonWithAddress::getId).asc()
+                .list();
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getName()).isEqualTo("Alice");
+        assertThat(result.get(1).getName()).isEqualTo("Albert");
+    }
+
+    // ── 嵌入字段条件查询 ──
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should query by embedded city field")
+    void shouldQueryByEmbeddedCity(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                TestDataFactory.createPersonWithAddress(610L, "U1", new Address("A St", "Springfield", "111")),
+                TestDataFactory.createPersonWithAddress(611L, "U2", new Address("B St", "Metropolis", "222"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getAddress).get(Address::getCity).eq("Springfield")
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(610L);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should query by embedded zipCode field")
+    void shouldQueryByEmbeddedZipCode(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                TestDataFactory.createPersonWithAddress(612L, "U1", new Address("1st Ave", "NYC", "10001")),
+                TestDataFactory.createPersonWithAddress(613L, "U2", new Address("2nd Ave", "NYC", "10002"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getAddress).get(Address::getZipCode).eq("10001")
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(612L);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should query by embedded street field with like")
+    void shouldQueryByEmbeddedStreetLike(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                TestDataFactory.createPersonWithAddress(614L, "U1", new Address("Market Street", "SF", "94101")),
+                TestDataFactory.createPersonWithAddress(615L, "U2", new Address("Market Road", "LA", "90001")),
+                TestDataFactory.createPersonWithAddress(616L, "U3", new Address("Broadway", "NYC", "10001"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getAddress).get(Address::getStreet).like("Market%")
+                .orderBy(PersonWithAddress::getId).asc()
+                .list();
+        assertThat(result).hasSize(2);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should return empty when querying non-existent embedded city")
+    void shouldQueryByEmbeddedCityNonExistent(IntegrationTestContext context) {
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getAddress).get(Address::getCity).eq("NONEXISTENT")
+                .list();
+        assertThat(result).isEmpty();
+    }
+
+    // ── 多条件组合查询（AND）──
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should query by name and embedded city combined")
+    void shouldQueryByNameAndEmbeddedCity(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                TestDataFactory.createPersonWithAddress(620L, "Alice", new Address("1st St", "Springfield", "111")),
+                TestDataFactory.createPersonWithAddress(621L, "Alice", new Address("2nd St", "Metropolis", "222")),
+                TestDataFactory.createPersonWithAddress(622L, "Bob", new Address("3rd St", "Springfield", "333"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getName).eq("Alice")
+                .where(PersonWithAddress::getAddress).get(Address::getCity).eq("Springfield")
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(620L);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should query by embedded city and zipCode combined")
+    void shouldQueryByEmbeddedCityAndZipCode(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                TestDataFactory.createPersonWithAddress(623L, "U1", new Address("A St", "SF", "94101")),
+                TestDataFactory.createPersonWithAddress(624L, "U2", new Address("B St", "SF", "94102")),
+                TestDataFactory.createPersonWithAddress(625L, "U3", new Address("C St", "LA", "94101"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getAddress).get(Address::getCity).eq("SF")
+                .where(PersonWithAddress::getAddress).get(Address::getZipCode).eq("94102")
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(624L);
+    }
+
+    // ── 多层嵌套嵌入字段条件查询 ──
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should query by nested embedded zip code (address.zip.code)")
+    void shouldQueryByNestedEmbeddedZipCode(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                TestDataFactory.createPersonWithCrossLayerEmbedded(500L, "U1", "SF", "Market", "94105", "10001"),
+                TestDataFactory.createPersonWithCrossLayerEmbedded(501L, "U2", "NY", "5th Ave", "10001", "90210")
+        ), context.getEntityContext(PersonWithCrossLayerEmbedded.class));
+
+        List<PersonWithCrossLayerEmbedded> result = context.queryPersonWithCrossLayerEmbedded()
+                .where(PersonWithCrossLayerEmbedded::getAddress).get(AddressWithZip::getZip).get(ZipCode::getCode).eq("94105")
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(500L);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should query by secondary zip code with attribute override")
+    void shouldQueryBySecondaryZipCode(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                TestDataFactory.createPersonWithCrossLayerEmbedded(502L, "U1", "SF", "Market", "94105", "10001"),
+                TestDataFactory.createPersonWithCrossLayerEmbedded(503L, "U2", "NY", "5th Ave", "10001", "90210")
+        ), context.getEntityContext(PersonWithCrossLayerEmbedded.class));
+
+        List<PersonWithCrossLayerEmbedded> result = context.queryPersonWithCrossLayerEmbedded()
+                .where(PersonWithCrossLayerEmbedded::getSecondaryZip).get(ZipCode::getCode).eq("90210")
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(503L);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should query by nested city and zip code combined")
+    void shouldQueryByNestedCityAndZipCode(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                TestDataFactory.createPersonWithCrossLayerEmbedded(504L, "U1", "SF", "Market", "94105", "10001"),
+                TestDataFactory.createPersonWithCrossLayerEmbedded(505L, "U2", "SF", "Market", "94102", "10002"),
+                TestDataFactory.createPersonWithCrossLayerEmbedded(506L, "U3", "LA", "Broadway", "94105", "10003")
+        ), context.getEntityContext(PersonWithCrossLayerEmbedded.class));
+
+        List<PersonWithCrossLayerEmbedded> result = context.queryPersonWithCrossLayerEmbedded()
+                .where(PersonWithCrossLayerEmbedded::getAddress).get(AddressWithZip::getCity).eq("SF")
+                .where(PersonWithCrossLayerEmbedded::getAddress).get(AddressWithZip::getZip).get(ZipCode::getCode).eq("94102")
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(505L);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should return empty when querying non-existent nested zip code")
+    void shouldQueryByNestedEmbeddedZipCodeNonExistent(IntegrationTestContext context) {
+        List<PersonWithCrossLayerEmbedded> result = context.queryPersonWithCrossLayerEmbedded()
+                .where(PersonWithCrossLayerEmbedded::getAddress).get(AddressWithZip::getZip).get(ZipCode::getCode).eq("NONEXIST")
+                .list();
+        assertThat(result).isEmpty();
+    }
 }

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/EmbeddedCrudIntegrationTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/EmbeddedCrudIntegrationTest.java
@@ -1,0 +1,242 @@
+package io.github.nextentity.integration;
+
+import io.github.nextentity.integration.config.IntegrationTestContext;
+import io.github.nextentity.integration.config.IntegrationTestProvider;
+import io.github.nextentity.integration.config.fixtures.TestDataFactory;
+import io.github.nextentity.integration.entity.Address;
+import io.github.nextentity.integration.entity.AddressWithZip;
+import io.github.nextentity.integration.entity.PersonWithAddress;
+import io.github.nextentity.integration.entity.PersonWithCrossLayerEmbedded;
+import io.github.nextentity.integration.entity.ZipCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Embedded CRUD Integration Tests")
+public class EmbeddedCrudIntegrationTest {
+
+    @AfterEach
+    void tearDown() {
+        var context = IntegrationTestProvider.getEntityManagerContext();
+        if (context != null) {
+            context.reset();
+        }
+    }
+
+    // ── 单层嵌入 CRUD ──
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should insert entity with embedded address")
+    void shouldInsertEntityWithEmbeddedAddress(IntegrationTestContext context) {
+        PersonWithAddress emp = TestDataFactory.createPersonWithAddress(
+                100L, "Test User", new Address("Market St", "San Francisco", "94105"));
+
+        context.getUpdateExecutor().insert(emp, context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(100L)
+                .list();
+        assertThat(result).hasSize(1);
+        PersonWithAddress inserted = result.get(0);
+        assertThat(inserted.getName()).isEqualTo("Test User");
+        assertThat(inserted.getAddress()).isNotNull();
+        assertThat(inserted.getAddress().getStreet()).isEqualTo("Market St");
+        assertThat(inserted.getAddress().getCity()).isEqualTo("San Francisco");
+        assertThat(inserted.getAddress().getZipCode()).isEqualTo("94105");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should update embedded address fields")
+    void shouldUpdateEmbeddedAddress(IntegrationTestContext context) {
+        PersonWithAddress emp = TestDataFactory.createPersonWithAddress(
+                200L, "Update User", new Address("5th Ave", "New York", "10001"));
+        context.getUpdateExecutor().insert(emp, context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> list = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(200L)
+                .list();
+        assertThat(list).hasSize(1);
+        PersonWithAddress loaded = list.get(0);
+        assertThat(loaded.getAddress().getCity()).isEqualTo("New York");
+
+        loaded.getAddress().setCity("Boston");
+        loaded.getAddress().setZipCode("02101");
+        context.getUpdateExecutor().update(loaded, context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> updatedList = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(200L)
+                .list();
+        assertThat(updatedList).hasSize(1);
+        PersonWithAddress updated = updatedList.get(0);
+        assertThat(updated.getAddress().getCity()).isEqualTo("Boston");
+        assertThat(updated.getAddress().getZipCode()).isEqualTo("02101");
+        assertThat(updated.getAddress().getStreet()).isEqualTo("5th Ave");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should delete entity with embedded address")
+    void shouldDeleteEntityWithEmbeddedAddress(IntegrationTestContext context) {
+        PersonWithAddress emp = TestDataFactory.createPersonWithAddress(
+                300L, "Delete User", new Address("Main St", "Chicago", "60601"));
+        context.getUpdateExecutor().insert(emp, context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> exists = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(300L)
+                .list();
+        assertThat(exists).hasSize(1);
+
+        context.getUpdateExecutor().delete(exists.get(0), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(300L)
+                .list();
+        assertThat(result).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should insert and query entity with null embedded address")
+    void shouldInsertAndQueryNullEmbeddedAddress(IntegrationTestContext context) {
+        PersonWithAddress emp = new PersonWithAddress(400L, "No Address", null);
+
+        context.getUpdateExecutor().insert(emp, context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(400L)
+                .list();
+        assertThat(result).hasSize(1);
+        PersonWithAddress loaded = result.get(0);
+        assertThat(loaded.getName()).isEqualTo("No Address");
+        assertThat(loaded.getAddress()).isNull();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should batch insert entities with embedded addresses")
+    void shouldBatchInsertEmbeddedAddressEntities(IntegrationTestContext context) {
+        List<PersonWithAddress> newEmployees = List.of(
+                TestDataFactory.createPersonWithAddress(500L, "User A", new Address("Pike St", "Seattle", "98101")),
+                TestDataFactory.createPersonWithAddress(501L, "User B", new Address("Ocean Dr", "Miami", "33101")),
+                TestDataFactory.createPersonWithAddress(502L, "User C", new Address("Broadway", "Denver", "80201"))
+        );
+
+        context.getUpdateExecutor().insertAll(newEmployees, context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).in(500L, 501L, 502L)
+                .orderBy(PersonWithAddress::getId).asc()
+                .list();
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getAddress().getCity()).isEqualTo("Seattle");
+        assertThat(result.get(1).getAddress().getCity()).isEqualTo("Miami");
+        assertThat(result.get(2).getAddress().getCity()).isEqualTo("Denver");
+    }
+
+    // ── 错层（cross-layer）嵌入 CRUD ──
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should insert cross-layer embedded entity")
+    void shouldInsertCrossLayerEmbeddedEntity(IntegrationTestContext context) {
+        PersonWithCrossLayerEmbedded emp = TestDataFactory.createPersonWithCrossLayerEmbedded(
+                100L, "Test User", "San Francisco", "Market St", "94105", "12345");
+
+        context.getUpdateExecutor().insert(emp, context.getEntityContext(PersonWithCrossLayerEmbedded.class));
+
+        List<PersonWithCrossLayerEmbedded> result = context.queryPersonWithCrossLayerEmbedded()
+                .where(PersonWithCrossLayerEmbedded::getId).eq(100L)
+                .list();
+        assertThat(result).hasSize(1);
+        PersonWithCrossLayerEmbedded inserted = result.get(0);
+        assertThat(inserted.getName()).isEqualTo("Test User");
+        assertThat(inserted.getAddress()).isNotNull();
+        assertThat(inserted.getAddress().getCity()).isEqualTo("San Francisco");
+        assertThat(inserted.getAddress().getZip()).isNotNull();
+        assertThat(inserted.getAddress().getZip().getCode()).isEqualTo("94105");
+        assertThat(inserted.getSecondaryZip()).isNotNull();
+        assertThat(inserted.getSecondaryZip().getCode()).isEqualTo("12345");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should update cross-layer embedded fields")
+    void shouldUpdateCrossLayerEmbeddedFields(IntegrationTestContext context) {
+        PersonWithCrossLayerEmbedded emp = TestDataFactory.createPersonWithCrossLayerEmbedded(
+                200L, "Update Test", "New York", "5th Ave", "10001", "90210");
+        context.getUpdateExecutor().insert(emp, context.getEntityContext(PersonWithCrossLayerEmbedded.class));
+
+        List<PersonWithCrossLayerEmbedded> list = context.queryPersonWithCrossLayerEmbedded()
+                .where(PersonWithCrossLayerEmbedded::getId).eq(200L)
+                .list();
+        assertThat(list).hasSize(1);
+        PersonWithCrossLayerEmbedded loaded = list.get(0);
+
+        loaded.getAddress().setCity("Boston");
+        loaded.getAddress().getZip().setCode("02101");
+        loaded.getSecondaryZip().setCode("77777");
+        context.getUpdateExecutor().update(loaded, context.getEntityContext(PersonWithCrossLayerEmbedded.class));
+
+        List<PersonWithCrossLayerEmbedded> updatedList = context.queryPersonWithCrossLayerEmbedded()
+                .where(PersonWithCrossLayerEmbedded::getId).eq(200L)
+                .list();
+        assertThat(updatedList).hasSize(1);
+        PersonWithCrossLayerEmbedded updated = updatedList.get(0);
+        assertThat(updated.getAddress().getCity()).isEqualTo("Boston");
+        assertThat(updated.getAddress().getZip().getCode()).isEqualTo("02101");
+        assertThat(updated.getSecondaryZip().getCode()).isEqualTo("77777");
+        assertThat(updated.getAddress().getStreet()).isEqualTo("5th Ave");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should batch insert cross-layer embedded entities")
+    void shouldBatchInsertCrossLayerEmbedded(IntegrationTestContext context) {
+        List<PersonWithCrossLayerEmbedded> newEmployees = List.of(
+                TestDataFactory.createPersonWithCrossLayerEmbedded(300L, "User A", "Seattle", "Pike St", "98101", "10001"),
+                TestDataFactory.createPersonWithCrossLayerEmbedded(301L, "User B", "Miami", "Ocean Dr", "33101", "10002"),
+                TestDataFactory.createPersonWithCrossLayerEmbedded(302L, "User C", "Denver", "Broadway", "80201", "10003")
+        );
+
+        context.getUpdateExecutor().insertAll(newEmployees, context.getEntityContext(PersonWithCrossLayerEmbedded.class));
+
+        List<PersonWithCrossLayerEmbedded> result = context.queryPersonWithCrossLayerEmbedded()
+                .where(PersonWithCrossLayerEmbedded::getId).in(300L, 301L, 302L)
+                .orderBy(PersonWithCrossLayerEmbedded::getId).asc()
+                .list();
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getAddress().getZip().getCode()).isEqualTo("98101");
+        assertThat(result.get(1).getSecondaryZip().getCode()).isEqualTo("10002");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Should update cross-layer embedded via conditional update API")
+    void shouldConditionalUpdateCrossLayerEmbedded(IntegrationTestContext context) {
+        PersonWithCrossLayerEmbedded emp = TestDataFactory.createPersonWithCrossLayerEmbedded(
+                400L, "Original Name", "New York", "5th Ave", "10001", "90210");
+        context.getUpdateExecutor().insert(emp, context.getEntityContext(PersonWithCrossLayerEmbedded.class));
+
+        context.doInTransaction(() -> {
+            int affected = context.update(PersonWithCrossLayerEmbedded.class)
+                    .set(PersonWithCrossLayerEmbedded::getName, "Updated Name")
+                    .where(PersonWithCrossLayerEmbedded::getId).eq(400L)
+                    .execute();
+            assertThat(affected).isEqualTo(1);
+        });
+
+        List<PersonWithCrossLayerEmbedded> result = context.queryPersonWithCrossLayerEmbedded()
+                .where(PersonWithCrossLayerEmbedded::getId).eq(400L)
+                .list();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("Updated Name");
+        assertThat(result.get(0).getAddress().getCity()).isEqualTo("New York");
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/EmbeddedFieldCrudIntegrationTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/EmbeddedFieldCrudIntegrationTest.java
@@ -1,0 +1,353 @@
+package io.github.nextentity.integration;
+
+import io.github.nextentity.integration.config.IntegrationTestContext;
+import io.github.nextentity.integration.config.IntegrationTestProvider;
+import io.github.nextentity.api.EntityPath;
+import io.github.nextentity.integration.entity.Address;
+import io.github.nextentity.integration.entity.ContactInfo;
+import io.github.nextentity.integration.entity.PersonWithAddress;
+import io.github.nextentity.integration.entity.PersonWithNestedAddress;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Embedded Field CRUD Integration Tests")
+public class EmbeddedFieldCrudIntegrationTest {
+
+    @AfterEach
+    void tearDown() {
+        var context = IntegrationTestProvider.getEntityManagerContext();
+        if (context != null) {
+            context.reset();
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Create: single person with @Embedded address")
+    void shouldCreatePersonWithEmbeddedAddress(IntegrationTestContext context) {
+        Address address = new Address("123 Main St", "Springfield", "12345");
+        PersonWithAddress person = new PersonWithAddress(100L, "John Doe", address);
+
+        context.getUpdateExecutor().insert(person, context.getEntityContext(PersonWithAddress.class));
+
+        PersonWithAddress found = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(100L)
+                .first();
+        assertThat(found).isNotNull();
+        assertThat(found.getName()).isEqualTo("John Doe");
+        assertThat(found.getAddress()).isNotNull();
+        assertThat(found.getAddress().getStreet()).isEqualTo("123 Main St");
+        assertThat(found.getAddress().getCity()).isEqualTo("Springfield");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Create: single person with nested @Embedded (ContactInfo > Address)")
+    void shouldCreatePersonWithNestedEmbedded(IntegrationTestContext context) {
+        Address addr = new Address("456 Oak Ave", "Metropolis", "67890");
+        ContactInfo contact = new ContactInfo("john@example.com", "555-0100", addr);
+        PersonWithNestedAddress person = new PersonWithNestedAddress(200L, "Jane Doe", contact);
+
+        context.getUpdateExecutor().insert(person, context.getEntityContext(PersonWithNestedAddress.class));
+
+        PersonWithNestedAddress found = context.queryPersonWithNestedAddresses()
+                .where(PersonWithNestedAddress::getId).eq(200L)
+                .first();
+        assertThat(found).isNotNull();
+        assertThat(found.getName()).isEqualTo("Jane Doe");
+        assertThat(found.getContactInfo().getEmail()).isEqualTo("john@example.com");
+        assertThat(found.getContactInfo().getAddress().getStreet()).isEqualTo("456 Oak Ave");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Create: batch insert persons with @Embedded address")
+    void shouldBatchCreatePersonsWithEmbedded(IntegrationTestContext context) {
+        PersonWithAddress p1 = new PersonWithAddress(110L, "Alice", new Address("1st St", "A", "111"));
+        PersonWithAddress p2 = new PersonWithAddress(111L, "Bob", new Address("2nd Ave", "B", "222"));
+
+        context.getUpdateExecutor().insertAll(List.of(p1, p2),
+                context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> all = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).in(110L, 111L)
+                .orderBy(PersonWithAddress::getId).asc()
+                .list();
+        assertThat(all).hasSize(2);
+        assertThat(all.get(0).getAddress().getStreet()).isEqualTo("1st St");
+        assertThat(all.get(1).getAddress().getStreet()).isEqualTo("2nd Ave");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Read: query person by id returns complete @Embedded fields")
+    void shouldReadPersonByIdWithEmbeddedFields(IntegrationTestContext context) {
+        Address address = new Address("999 Query Blvd", "TestCity", "99999");
+        context.getUpdateExecutor().insert(
+                new PersonWithAddress(300L, "Query User", address),
+                context.getEntityContext(PersonWithAddress.class));
+
+        PersonWithAddress found = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(300L)
+                .first();
+
+        assertThat(found).isNotNull();
+        assertThat(found.getAddress().getStreet()).isEqualTo("999 Query Blvd");
+        assertThat(found.getAddress().getCity()).isEqualTo("TestCity");
+        assertThat(found.getAddress().getZipCode()).isEqualTo("99999");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Read: query all returns list with embedded fields")
+    void shouldReadAllPersonsWithEmbeddedFields(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                new PersonWithAddress(310L, "U1", new Address("A St", "Acity", "001")),
+                new PersonWithAddress(311L, "U2", new Address("B St", "Bcity", "002"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> all = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).in(310L, 311L)
+                .orderBy(PersonWithAddress::getId).asc()
+                .list();
+
+        assertThat(all).hasSize(2);
+        assertThat(all.get(0).getAddress().getCity()).isEqualTo("Acity");
+        assertThat(all.get(1).getAddress().getCity()).isEqualTo("Bcity");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Read: query person with nested @Embedded returns all levels")
+    void shouldReadNestedEmbeddedPerson(IntegrationTestContext context) {
+        Address addr = new Address("777 Deep Rd", "DeepCity", "77777");
+        ContactInfo contact = new ContactInfo("deep@test.com", "555-7777", addr);
+        context.getUpdateExecutor().insert(
+                new PersonWithNestedAddress(320L, "Deep User", contact),
+                context.getEntityContext(PersonWithNestedAddress.class));
+
+        PersonWithNestedAddress found = context.queryPersonWithNestedAddresses()
+                .where(PersonWithNestedAddress::getId).eq(320L)
+                .first();
+
+        assertThat(found.getContactInfo().getEmail()).isEqualTo("deep@test.com");
+        assertThat(found.getContactInfo().getAddress().getCity()).isEqualTo("DeepCity");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Read: query non-existent returns null")
+    void shouldReadNonExistentReturnsNull(IntegrationTestContext context) {
+        PersonWithAddress found = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(99999L)
+                .first();
+
+        assertThat(found).isNull();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Read: filter by @Embedded internal field via path chain")
+    void shouldFilterByEmbeddedInternalField(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                new PersonWithAddress(330L, "U1", new Address("Elm St", "Springfield", "111")),
+                new PersonWithAddress(331L, "U2", new Address("Oak Ave", "Metropolis", "222"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getAddress).get(Address::getCity).eq("Springfield")
+                .orderBy(PersonWithAddress::getId).asc()
+                .list();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getAddress().getCity()).isEqualTo("Springfield");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Read: filter by @Embedded internal field via EntityPath API")
+    void shouldFilterByEmbeddedFieldViaEntityPath(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                new PersonWithAddress(340L, "U1", new Address("Broadway", "NYC", "001")),
+                new PersonWithAddress(341L, "U2", new Address("5th Ave", "NYC", "002"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(EntityPath.of(PersonWithAddress::getAddress).get(Address::getStreet)).eq("Broadway")
+                .list();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getAddress().getStreet()).isEqualTo("Broadway");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Read: filter by nested @Embedded internal field (ContactInfo.Address.city)")
+    void shouldFilterByNestedEmbeddedInternalField(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                new PersonWithNestedAddress(350L, "NU1",
+                        new ContactInfo("a@x.com", "111", new Address("1st", "Gotham", "000"))),
+                new PersonWithNestedAddress(351L, "NU2",
+                        new ContactInfo("b@x.com", "222", new Address("2nd", "Star City", "000")))
+        ), context.getEntityContext(PersonWithNestedAddress.class));
+
+        List<PersonWithNestedAddress> result = context.queryPersonWithNestedAddresses()
+                .where(PersonWithNestedAddress::getContactInfo).get(ContactInfo::getAddress).get(Address::getCity).eq("Gotham")
+                .list();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getContactInfo().getAddress().getCity()).isEqualTo("Gotham");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Read: query by @Embedded zipCode returns empty for non-existent value")
+    void shouldQueryByEmbeddedZipCodeNonExistent(IntegrationTestContext context) {
+        List<PersonWithAddress> result = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getAddress).get(Address::getZipCode).eq("NONEXIST")
+                .list();
+
+        assertThat(result).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Update: single entity embedded street field")
+    void shouldUpdateEmbeddedStreetField(IntegrationTestContext context) {
+        context.getUpdateExecutor().insert(
+                new PersonWithAddress(400L, "Batman", new Address("789 Pine Rd", "Gotham", "11111")),
+                context.getEntityContext(PersonWithAddress.class));
+
+        PersonWithAddress toUpdate = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(400L).first();
+        toUpdate.getAddress().setStreet("321 Elm St");
+        context.getUpdateExecutor().update(toUpdate, context.getEntityContext(PersonWithAddress.class));
+
+        PersonWithAddress updated = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(400L).first();
+        assertThat(updated.getAddress().getStreet()).isEqualTo("321 Elm St");
+        assertThat(updated.getAddress().getCity()).isEqualTo("Gotham");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Update: all embedded fields changed")
+    void shouldUpdateAllEmbeddedFields(IntegrationTestContext context) {
+        context.getUpdateExecutor().insert(
+                new PersonWithAddress(410L, "Spiderman", new Address("Old St", "OldCity", "00000")),
+                context.getEntityContext(PersonWithAddress.class));
+
+        PersonWithAddress toUpdate = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(410L).first();
+        toUpdate.setAddress(new Address("New St", "NewCity", "99999"));
+        context.getUpdateExecutor().update(toUpdate, context.getEntityContext(PersonWithAddress.class));
+
+        PersonWithAddress updated = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(410L).first();
+        assertThat(updated.getAddress().getStreet()).isEqualTo("New St");
+        assertThat(updated.getAddress().getCity()).isEqualTo("NewCity");
+        assertThat(updated.getAddress().getZipCode()).isEqualTo("99999");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Update: nested @Embedded fields (ContactInfo.email + Address.street)")
+    void shouldUpdateNestedEmbeddedFields(IntegrationTestContext context) {
+        context.getUpdateExecutor().insert(
+                new PersonWithNestedAddress(420L, "Nested Update",
+                        new ContactInfo("old@test.com", "555-0000",
+                                new Address("777 Old Rd", "OldCity", "77777"))),
+                context.getEntityContext(PersonWithNestedAddress.class));
+
+        PersonWithNestedAddress toUpdate = context.queryPersonWithNestedAddresses()
+                .where(PersonWithNestedAddress::getId).eq(420L).first();
+        toUpdate.getContactInfo().setEmail("new@test.com");
+        toUpdate.getContactInfo().getAddress().setStreet("888 New Rd");
+        context.getUpdateExecutor().update(toUpdate, context.getEntityContext(PersonWithNestedAddress.class));
+
+        PersonWithNestedAddress updated = context.queryPersonWithNestedAddresses()
+                .where(PersonWithNestedAddress::getId).eq(420L).first();
+        assertThat(updated.getContactInfo().getEmail()).isEqualTo("new@test.com");
+        assertThat(updated.getContactInfo().getAddress().getStreet()).isEqualTo("888 New Rd");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Update: batch update embedded fields")
+    void shouldBatchUpdateEmbeddedFields(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                new PersonWithAddress(430L, "Bulk1", new Address("A St", "CityA", "001")),
+                new PersonWithAddress(431L, "Bulk2", new Address("B St", "CityB", "002"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> list = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).in(430L, 431L)
+                .orderBy(PersonWithAddress::getId).asc()
+                .list();
+        list.get(0).getAddress().setCity("UpdatedA");
+        list.get(1).getAddress().setCity("UpdatedB");
+        context.getUpdateExecutor().updateAll(list, context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> updated = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).in(430L, 431L)
+                .orderBy(PersonWithAddress::getId).asc()
+                .list();
+        assertThat(updated.get(0).getAddress().getCity()).isEqualTo("UpdatedA");
+        assertThat(updated.get(1).getAddress().getCity()).isEqualTo("UpdatedB");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Delete: single person with @Embedded address")
+    void shouldDeletePersonWithEmbeddedAddress(IntegrationTestContext context) {
+        context.getUpdateExecutor().insert(
+                new PersonWithAddress(500L, "Delete Me", new Address("555 Cedar Ln", "Star City", "33333")),
+                context.getEntityContext(PersonWithAddress.class));
+
+        assertThat(context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(500L).first()).isNotNull();
+
+        PersonWithAddress toDelete = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(500L).first();
+        context.getUpdateExecutor().delete(toDelete, context.getEntityContext(PersonWithAddress.class));
+
+        assertThat(context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(500L).first()).isNull();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Delete: batch delete persons with @Embedded address")
+    void shouldBatchDeletePersonsWithEmbeddedAddress(IntegrationTestContext context) {
+        context.getUpdateExecutor().insertAll(List.of(
+                new PersonWithAddress(510L, "Del1", new Address("X St", "X", "000")),
+                new PersonWithAddress(511L, "Del2", new Address("Y St", "Y", "000"))
+        ), context.getEntityContext(PersonWithAddress.class));
+
+        List<PersonWithAddress> toDelete = context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).in(510L, 511L)
+                .orderBy(PersonWithAddress::getId).asc()
+                .list();
+        assertThat(toDelete).hasSize(2);
+
+        context.getUpdateExecutor().deleteAll(toDelete, context.getEntityContext(PersonWithAddress.class));
+
+        assertThat(context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).in(510L, 511L)
+                .list()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IntegrationTestProvider.class)
+    @DisplayName("Delete: delete non-existent person with @Embedded address")
+    void shouldDeleteNonExistentPersonWithEmbedded(IntegrationTestContext context) {
+        assertThat(context.queryPersonWithAddresses()
+                .where(PersonWithAddress::getId).eq(99999L).first()).isNull();
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestApplication.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestApplication.java
@@ -19,6 +19,8 @@ import io.github.nextentity.integration.entity.Employee;
 import io.github.nextentity.integration.entity.LockableEntity;
 import io.github.nextentity.integration.entity.PersonWithAddress;
 import io.github.nextentity.integration.entity.PersonWithNestedAddress;
+import io.github.nextentity.integration.entity.PersonWithNestedOverriddenContact;
+import io.github.nextentity.integration.entity.PersonWithOverriddenAddress;
 import io.github.nextentity.integration.entity.SalesOrder;
 import io.github.nextentity.jdbc.*;
 import io.github.nextentity.jpa.JpaConfig;
@@ -154,6 +156,8 @@ public class IntegrationTestApplication {
         private static final List<Class<?>> RESET_ORDER = List.of(
                 SalesOrder.class,
                 Customer.class,
+                PersonWithNestedOverriddenContact.class,
+                PersonWithOverriddenAddress.class,
                 PersonWithNestedAddress.class,
                 PersonWithAddress.class,
                 Employee.class,

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestApplication.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestApplication.java
@@ -17,6 +17,8 @@ import io.github.nextentity.integration.entity.Customer;
 import io.github.nextentity.integration.entity.Department;
 import io.github.nextentity.integration.entity.Employee;
 import io.github.nextentity.integration.entity.LockableEntity;
+import io.github.nextentity.integration.entity.PersonWithAddress;
+import io.github.nextentity.integration.entity.PersonWithNestedAddress;
 import io.github.nextentity.integration.entity.SalesOrder;
 import io.github.nextentity.jdbc.*;
 import io.github.nextentity.jpa.JpaConfig;
@@ -152,6 +154,8 @@ public class IntegrationTestApplication {
         private static final List<Class<?>> RESET_ORDER = List.of(
                 SalesOrder.class,
                 Customer.class,
+                PersonWithNestedAddress.class,
+                PersonWithAddress.class,
                 Employee.class,
                 Department.class,
                 Category.class,

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestApplication.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestApplication.java
@@ -18,6 +18,7 @@ import io.github.nextentity.integration.entity.Department;
 import io.github.nextentity.integration.entity.Employee;
 import io.github.nextentity.integration.entity.LockableEntity;
 import io.github.nextentity.integration.entity.PersonWithAddress;
+import io.github.nextentity.integration.entity.PersonWithCrossLayerEmbedded;
 import io.github.nextentity.integration.entity.PersonWithNestedAddress;
 import io.github.nextentity.integration.entity.PersonWithNestedOverriddenContact;
 import io.github.nextentity.integration.entity.PersonWithOverriddenAddress;
@@ -156,6 +157,7 @@ public class IntegrationTestApplication {
         private static final List<Class<?>> RESET_ORDER = List.of(
                 SalesOrder.class,
                 Customer.class,
+                PersonWithCrossLayerEmbedded.class,
                 PersonWithNestedOverriddenContact.class,
                 PersonWithOverriddenAddress.class,
                 PersonWithNestedAddress.class,

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestContext.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestContext.java
@@ -78,6 +78,10 @@ public interface IntegrationTestContext {
         return new EntityQueryImpl<>(getEntityContext(PersonWithNestedOverriddenContact.class));
     }
 
+    default EntityQueryImpl<PersonWithCrossLayerEmbedded> queryPersonWithCrossLayerEmbedded() {
+        return new EntityQueryImpl<>(getEntityContext(PersonWithCrossLayerEmbedded.class));
+    }
+
     @NonNull IntegrationTestContext reset();
 
     <T> T doInTransaction(Supplier<T> runnable);

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestContext.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestContext.java
@@ -62,6 +62,14 @@ public interface IntegrationTestContext {
         return new EntityQueryImpl<>(getEntityContext(Customer.class));
     }
 
+    default EntityQueryImpl<PersonWithAddress> queryPersonWithAddresses() {
+        return new EntityQueryImpl<>(getEntityContext(PersonWithAddress.class));
+    }
+
+    default EntityQueryImpl<PersonWithNestedAddress> queryPersonWithNestedAddresses() {
+        return new EntityQueryImpl<>(getEntityContext(PersonWithNestedAddress.class));
+    }
+
     @NonNull IntegrationTestContext reset();
 
     <T> T doInTransaction(Supplier<T> runnable);

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestContext.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/IntegrationTestContext.java
@@ -70,6 +70,14 @@ public interface IntegrationTestContext {
         return new EntityQueryImpl<>(getEntityContext(PersonWithNestedAddress.class));
     }
 
+    default EntityQueryImpl<PersonWithOverriddenAddress> queryPersonWithOverriddenAddresses() {
+        return new EntityQueryImpl<>(getEntityContext(PersonWithOverriddenAddress.class));
+    }
+
+    default EntityQueryImpl<PersonWithNestedOverriddenContact> queryPersonWithNestedOverriddenContacts() {
+        return new EntityQueryImpl<>(getEntityContext(PersonWithNestedOverriddenContact.class));
+    }
+
     @NonNull IntegrationTestContext reset();
 
     <T> T doInTransaction(Supplier<T> runnable);

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/H2EnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/H2EnvironmentVariables.java
@@ -35,6 +35,8 @@ public class H2EnvironmentVariables implements DatabaseEnvironmentVariables {
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_nested_address",
+                "DROP TABLE IF EXISTS person_with_address",
                 "DROP TABLE IF EXISTS employee",
                 "DROP TABLE IF EXISTS department",
                 "DROP TABLE IF EXISTS category",
@@ -101,6 +103,26 @@ public class H2EnvironmentVariables implements DatabaseEnvironmentVariables {
                             order_no VARCHAR(100) NOT NULL,
                             customer_id BIGINT,
                             amount DECIMAL(19,2)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_address (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            street VARCHAR(100),
+                            city VARCHAR(100),
+                            zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_nested_address (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            email VARCHAR(100),
+                            phone VARCHAR(20),
+                            street VARCHAR(100),
+                            city VARCHAR(100),
+                            zip_code VARCHAR(20)
                         )
                         """
         );

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/H2EnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/H2EnvironmentVariables.java
@@ -35,6 +35,7 @@ public class H2EnvironmentVariables implements DatabaseEnvironmentVariables {
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_cross_layer_embedded",
                 "DROP TABLE IF EXISTS person_with_nested_overridden_contact",
                 "DROP TABLE IF EXISTS person_with_overridden_address",
                 "DROP TABLE IF EXISTS person_with_nested_address",
@@ -145,6 +146,16 @@ public class H2EnvironmentVariables implements DatabaseEnvironmentVariables {
                             deep_street VARCHAR(100),
                             city VARCHAR(100),
                             zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_cross_layer_embedded (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            city VARCHAR(100),
+                            street VARCHAR(100),
+                            code VARCHAR(20),
+                            alt_code VARCHAR(20)
                         )
                         """
         );

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/H2EnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/H2EnvironmentVariables.java
@@ -35,6 +35,8 @@ public class H2EnvironmentVariables implements DatabaseEnvironmentVariables {
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_nested_overridden_contact",
+                "DROP TABLE IF EXISTS person_with_overridden_address",
                 "DROP TABLE IF EXISTS person_with_nested_address",
                 "DROP TABLE IF EXISTS person_with_address",
                 "DROP TABLE IF EXISTS employee",
@@ -121,6 +123,26 @@ public class H2EnvironmentVariables implements DatabaseEnvironmentVariables {
                             email VARCHAR(100),
                             phone VARCHAR(20),
                             street VARCHAR(100),
+                            city VARCHAR(100),
+                            zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_overridden_address (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            addr_street VARCHAR(100),
+                            addr_city VARCHAR(100),
+                            zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_nested_overridden_contact (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            contact_email VARCHAR(100),
+                            phone VARCHAR(20),
+                            deep_street VARCHAR(100),
                             city VARCHAR(100),
                             zip_code VARCHAR(20)
                         )

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/MysqlEnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/MysqlEnvironmentVariables.java
@@ -33,6 +33,8 @@ public class MysqlEnvironmentVariables extends DbContainerEnvironmentVariables {
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_nested_overridden_contact",
+                "DROP TABLE IF EXISTS person_with_overridden_address",
                 "DROP TABLE IF EXISTS person_with_nested_address",
                 "DROP TABLE IF EXISTS person_with_address",
                 "DROP TABLE IF EXISTS employee",
@@ -119,6 +121,26 @@ public class MysqlEnvironmentVariables extends DbContainerEnvironmentVariables {
                             email VARCHAR(100),
                             phone VARCHAR(20),
                             street VARCHAR(100),
+                            city VARCHAR(100),
+                            zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_overridden_address (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            addr_street VARCHAR(100),
+                            addr_city VARCHAR(100),
+                            zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_nested_overridden_contact (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            contact_email VARCHAR(100),
+                            phone VARCHAR(20),
+                            deep_street VARCHAR(100),
                             city VARCHAR(100),
                             zip_code VARCHAR(20)
                         )

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/MysqlEnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/MysqlEnvironmentVariables.java
@@ -33,6 +33,7 @@ public class MysqlEnvironmentVariables extends DbContainerEnvironmentVariables {
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_cross_layer_embedded",
                 "DROP TABLE IF EXISTS person_with_nested_overridden_contact",
                 "DROP TABLE IF EXISTS person_with_overridden_address",
                 "DROP TABLE IF EXISTS person_with_nested_address",
@@ -143,6 +144,16 @@ public class MysqlEnvironmentVariables extends DbContainerEnvironmentVariables {
                             deep_street VARCHAR(100),
                             city VARCHAR(100),
                             zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_cross_layer_embedded (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            city VARCHAR(100),
+                            street VARCHAR(100),
+                            code VARCHAR(20),
+                            alt_code VARCHAR(20)
                         )
                         """
         );

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/MysqlEnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/MysqlEnvironmentVariables.java
@@ -33,6 +33,8 @@ public class MysqlEnvironmentVariables extends DbContainerEnvironmentVariables {
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_nested_address",
+                "DROP TABLE IF EXISTS person_with_address",
                 "DROP TABLE IF EXISTS employee",
                 "DROP TABLE IF EXISTS department",
                 "DROP TABLE IF EXISTS category",
@@ -99,6 +101,26 @@ public class MysqlEnvironmentVariables extends DbContainerEnvironmentVariables {
                             order_no VARCHAR(100) NOT NULL,
                             customer_id BIGINT,
                             amount DECIMAL(19,2)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_address (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            street VARCHAR(100),
+                            city VARCHAR(100),
+                            zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_nested_address (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            email VARCHAR(100),
+                            phone VARCHAR(20),
+                            street VARCHAR(100),
+                            city VARCHAR(100),
+                            zip_code VARCHAR(20)
                         )
                         """
         );

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/PostgresqlEnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/PostgresqlEnvironmentVariables.java
@@ -34,6 +34,8 @@ public class PostgresqlEnvironmentVariables extends DbContainerEnvironmentVariab
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_nested_address",
+                "DROP TABLE IF EXISTS person_with_address",
                 "DROP TABLE IF EXISTS employee",
                 "DROP TABLE IF EXISTS department",
                 "DROP TABLE IF EXISTS category",
@@ -100,6 +102,26 @@ public class PostgresqlEnvironmentVariables extends DbContainerEnvironmentVariab
                             order_no VARCHAR(100) NOT NULL,
                             customer_id BIGINT,
                             amount DECIMAL(19,2)
+                        )
+                        """,
+                """
+                        CREATE TABLE "person_with_address" (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            street VARCHAR(100),
+                            city VARCHAR(100),
+                            zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE "person_with_nested_address" (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            email VARCHAR(100),
+                            phone VARCHAR(20),
+                            street VARCHAR(100),
+                            city VARCHAR(100),
+                            zip_code VARCHAR(20)
                         )
                         """
         );

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/PostgresqlEnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/PostgresqlEnvironmentVariables.java
@@ -34,6 +34,8 @@ public class PostgresqlEnvironmentVariables extends DbContainerEnvironmentVariab
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_nested_overridden_contact",
+                "DROP TABLE IF EXISTS person_with_overridden_address",
                 "DROP TABLE IF EXISTS person_with_nested_address",
                 "DROP TABLE IF EXISTS person_with_address",
                 "DROP TABLE IF EXISTS employee",
@@ -120,6 +122,26 @@ public class PostgresqlEnvironmentVariables extends DbContainerEnvironmentVariab
                             email VARCHAR(100),
                             phone VARCHAR(20),
                             street VARCHAR(100),
+                            city VARCHAR(100),
+                            zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE "person_with_overridden_address" (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            addr_street VARCHAR(100),
+                            addr_city VARCHAR(100),
+                            zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE "person_with_nested_overridden_contact" (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            contact_email VARCHAR(100),
+                            phone VARCHAR(20),
+                            deep_street VARCHAR(100),
                             city VARCHAR(100),
                             zip_code VARCHAR(20)
                         )

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/PostgresqlEnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/PostgresqlEnvironmentVariables.java
@@ -34,6 +34,7 @@ public class PostgresqlEnvironmentVariables extends DbContainerEnvironmentVariab
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_cross_layer_embedded",
                 "DROP TABLE IF EXISTS person_with_nested_overridden_contact",
                 "DROP TABLE IF EXISTS person_with_overridden_address",
                 "DROP TABLE IF EXISTS person_with_nested_address",
@@ -144,6 +145,16 @@ public class PostgresqlEnvironmentVariables extends DbContainerEnvironmentVariab
                             deep_street VARCHAR(100),
                             city VARCHAR(100),
                             zip_code VARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE "person_with_cross_layer_embedded" (
+                            id BIGINT PRIMARY KEY,
+                            name VARCHAR(100),
+                            city VARCHAR(100),
+                            street VARCHAR(100),
+                            code VARCHAR(20),
+                            alt_code VARCHAR(20)
                         )
                         """
         );

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/SqlServerEnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/SqlServerEnvironmentVariables.java
@@ -31,6 +31,8 @@ public class SqlServerEnvironmentVariables extends DbContainerEnvironmentVariabl
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_nested_address",
+                "DROP TABLE IF EXISTS person_with_address",
                 "DROP TABLE IF EXISTS employee",
                 "DROP TABLE IF EXISTS department",
                 "DROP TABLE IF EXISTS category",
@@ -97,6 +99,26 @@ public class SqlServerEnvironmentVariables extends DbContainerEnvironmentVariabl
                             order_no NVARCHAR(100) NOT NULL,
                             customer_id BIGINT,
                             amount DECIMAL(19,2)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_address (
+                            id BIGINT PRIMARY KEY,
+                            name NVARCHAR(100),
+                            street NVARCHAR(100),
+                            city NVARCHAR(100),
+                            zip_code NVARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_nested_address (
+                            id BIGINT PRIMARY KEY,
+                            name NVARCHAR(100),
+                            email NVARCHAR(100),
+                            phone NVARCHAR(20),
+                            street NVARCHAR(100),
+                            city NVARCHAR(100),
+                            zip_code NVARCHAR(20)
                         )
                         """
         );

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/SqlServerEnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/SqlServerEnvironmentVariables.java
@@ -31,6 +31,8 @@ public class SqlServerEnvironmentVariables extends DbContainerEnvironmentVariabl
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_nested_overridden_contact",
+                "DROP TABLE IF EXISTS person_with_overridden_address",
                 "DROP TABLE IF EXISTS person_with_nested_address",
                 "DROP TABLE IF EXISTS person_with_address",
                 "DROP TABLE IF EXISTS employee",
@@ -117,6 +119,26 @@ public class SqlServerEnvironmentVariables extends DbContainerEnvironmentVariabl
                             email NVARCHAR(100),
                             phone NVARCHAR(20),
                             street NVARCHAR(100),
+                            city NVARCHAR(100),
+                            zip_code NVARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_overridden_address (
+                            id BIGINT PRIMARY KEY,
+                            name NVARCHAR(100),
+                            addr_street NVARCHAR(100),
+                            addr_city NVARCHAR(100),
+                            zip_code NVARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_nested_overridden_contact (
+                            id BIGINT PRIMARY KEY,
+                            name NVARCHAR(100),
+                            contact_email NVARCHAR(100),
+                            phone NVARCHAR(20),
+                            deep_street NVARCHAR(100),
                             city NVARCHAR(100),
                             zip_code NVARCHAR(20)
                         )

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/SqlServerEnvironmentVariables.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/env/SqlServerEnvironmentVariables.java
@@ -31,6 +31,7 @@ public class SqlServerEnvironmentVariables extends DbContainerEnvironmentVariabl
                 "DROP TABLE IF EXISTS auto_increment_entity",
                 "DROP TABLE IF EXISTS sales_order",
                 "DROP TABLE IF EXISTS customer",
+                "DROP TABLE IF EXISTS person_with_cross_layer_embedded",
                 "DROP TABLE IF EXISTS person_with_nested_overridden_contact",
                 "DROP TABLE IF EXISTS person_with_overridden_address",
                 "DROP TABLE IF EXISTS person_with_nested_address",
@@ -141,6 +142,16 @@ public class SqlServerEnvironmentVariables extends DbContainerEnvironmentVariabl
                             deep_street NVARCHAR(100),
                             city NVARCHAR(100),
                             zip_code NVARCHAR(20)
+                        )
+                        """,
+                """
+                        CREATE TABLE person_with_cross_layer_embedded (
+                            id BIGINT PRIMARY KEY,
+                            name NVARCHAR(100),
+                            city NVARCHAR(100),
+                            street NVARCHAR(100),
+                            code NVARCHAR(20),
+                            alt_code NVARCHAR(20)
                         )
                         """
         );

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/config/fixtures/TestDataFactory.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/config/fixtures/TestDataFactory.java
@@ -111,6 +111,17 @@ public class TestDataFactory {
         return customers;
     }
 
+    public static PersonWithAddress createPersonWithAddress(Long id, String name, Address address) {
+        return new PersonWithAddress(id, name, address);
+    }
+
+    public static PersonWithCrossLayerEmbedded createPersonWithCrossLayerEmbedded(
+            Long id, String name, String city, String street, String zipCode, String altCode) {
+        return new PersonWithCrossLayerEmbedded(id, name,
+                new AddressWithZip(city, street, new ZipCode(zipCode)),
+                new ZipCode(altCode));
+    }
+
     public static List<SalesOrder> createSalesOrders() {
         List<SalesOrder> orders = new ArrayList<>();
         orders.add(new SalesOrder(1L, "ORD-001", 1L, new BigDecimal("99.99")));

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/entity/Address.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/entity/Address.java
@@ -1,0 +1,44 @@
+package io.github.nextentity.integration.entity;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Address {
+
+    private String street;
+    private String city;
+    private String zipCode;
+
+    public Address() {
+    }
+
+    public Address(String street, String city, String zipCode) {
+        this.street = street;
+        this.city = city;
+        this.zipCode = zipCode;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getZipCode() {
+        return zipCode;
+    }
+
+    public void setZipCode(String zipCode) {
+        this.zipCode = zipCode;
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/entity/AddressWithZip.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/entity/AddressWithZip.java
@@ -1,0 +1,47 @@
+package io.github.nextentity.integration.entity;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+
+@Embeddable
+public class AddressWithZip {
+
+    private String city;
+    private String street;
+
+    @Embedded
+    private ZipCode zip;
+
+    public AddressWithZip() {
+    }
+
+    public AddressWithZip(String city, String street, ZipCode zip) {
+        this.city = city;
+        this.street = street;
+        this.zip = zip;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public ZipCode getZip() {
+        return zip;
+    }
+
+    public void setZip(ZipCode zip) {
+        this.zip = zip;
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/entity/ContactInfo.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/entity/ContactInfo.java
@@ -1,0 +1,47 @@
+package io.github.nextentity.integration.entity;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+
+@Embeddable
+public class ContactInfo {
+
+    private String email;
+    private String phone;
+
+    @Embedded
+    private Address address;
+
+    public ContactInfo() {
+    }
+
+    public ContactInfo(String email, String phone, Address address) {
+        this.email = email;
+        this.phone = phone;
+        this.address = address;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/entity/PersonWithAddress.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/entity/PersonWithAddress.java
@@ -1,0 +1,50 @@
+package io.github.nextentity.integration.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Id;
+
+@Entity
+public class PersonWithAddress {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @Embedded
+    private Address address;
+
+    public PersonWithAddress() {
+    }
+
+    public PersonWithAddress(Long id, String name, Address address) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/entity/PersonWithCrossLayerEmbedded.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/entity/PersonWithCrossLayerEmbedded.java
@@ -1,0 +1,65 @@
+package io.github.nextentity.integration.entity;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class PersonWithCrossLayerEmbedded {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @Embedded
+    private AddressWithZip address;
+
+    @Embedded
+    @AttributeOverride(name = "code", column = @Column(name = "alt_code"))
+    private ZipCode secondaryZip;
+
+    public PersonWithCrossLayerEmbedded() {
+    }
+
+    public PersonWithCrossLayerEmbedded(Long id, String name, AddressWithZip address, ZipCode secondaryZip) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+        this.secondaryZip = secondaryZip;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public AddressWithZip getAddress() {
+        return address;
+    }
+
+    public void setAddress(AddressWithZip address) {
+        this.address = address;
+    }
+
+    public ZipCode getSecondaryZip() {
+        return secondaryZip;
+    }
+
+    public void setSecondaryZip(ZipCode secondaryZip) {
+        this.secondaryZip = secondaryZip;
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/entity/PersonWithNestedAddress.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/entity/PersonWithNestedAddress.java
@@ -1,0 +1,50 @@
+package io.github.nextentity.integration.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Id;
+
+@Entity
+public class PersonWithNestedAddress {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @Embedded
+    private ContactInfo contactInfo;
+
+    public PersonWithNestedAddress() {
+    }
+
+    public PersonWithNestedAddress(Long id, String name, ContactInfo contactInfo) {
+        this.id = id;
+        this.name = name;
+        this.contactInfo = contactInfo;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ContactInfo getContactInfo() {
+        return contactInfo;
+    }
+
+    public void setContactInfo(ContactInfo contactInfo) {
+        this.contactInfo = contactInfo;
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/entity/PersonWithNestedOverriddenContact.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/entity/PersonWithNestedOverriddenContact.java
@@ -1,0 +1,57 @@
+package io.github.nextentity.integration.entity;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class PersonWithNestedOverriddenContact {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "email", column = @Column(name = "contact_email")),
+            @AttributeOverride(name = "address.street", column = @Column(name = "deep_street"))
+    })
+    private ContactInfo contactInfo;
+
+    public PersonWithNestedOverriddenContact() {
+    }
+
+    public PersonWithNestedOverriddenContact(Long id, String name, ContactInfo contactInfo) {
+        this.id = id;
+        this.name = name;
+        this.contactInfo = contactInfo;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ContactInfo getContactInfo() {
+        return contactInfo;
+    }
+
+    public void setContactInfo(ContactInfo contactInfo) {
+        this.contactInfo = contactInfo;
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/entity/PersonWithOverriddenAddress.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/entity/PersonWithOverriddenAddress.java
@@ -1,0 +1,57 @@
+package io.github.nextentity.integration.entity;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class PersonWithOverriddenAddress {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "street", column = @Column(name = "addr_street")),
+            @AttributeOverride(name = "city", column = @Column(name = "addr_city"))
+    })
+    private Address address;
+
+    public PersonWithOverriddenAddress() {
+    }
+
+    public PersonWithOverriddenAddress(Long id, String name, Address address) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/integration/entity/ZipCode.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/integration/entity/ZipCode.java
@@ -1,0 +1,24 @@
+package io.github.nextentity.integration.entity;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class ZipCode {
+
+    private String code;
+
+    public ZipCode() {
+    }
+
+    public ZipCode(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/nextentity-core/src/test/java/io/github/nextentity/jdbc/EmbeddedPersistSqlTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/jdbc/EmbeddedPersistSqlTest.java
@@ -291,15 +291,22 @@ class EmbeddedPersistSqlTest {
         }
 
         private long countOccurrences(String sql, String columnName) {
-            String quoted = detectQuote(sql) + columnName + detectQuote(sql);
+            String quoted = detectLeftQuote(sql) + columnName + detectRightQuote(sql);
             return Pattern.compile(Pattern.quote(quoted), Pattern.CASE_INSENSITIVE)
                     .matcher(sql).results().count();
         }
 
-        private String detectQuote(String sql) {
+        private String detectLeftQuote(String sql) {
             if (sql.contains("`")) return "`";
             if (sql.contains("\"")) return "\"";
             if (sql.contains("[")) return "[";
+            return "";
+        }
+
+        private String detectRightQuote(String sql) {
+            if (sql.contains("`")) return "`";
+            if (sql.contains("\"")) return "\"";
+            if (sql.contains("[")) return "]";
             return "";
         }
     }

--- a/nextentity-core/src/test/java/io/github/nextentity/jdbc/EmbeddedPersistSqlTest.java
+++ b/nextentity-core/src/test/java/io/github/nextentity/jdbc/EmbeddedPersistSqlTest.java
@@ -1,0 +1,306 @@
+package io.github.nextentity.jdbc;
+
+import io.github.nextentity.core.meta.EntityType;
+import io.github.nextentity.core.meta.impl.DefaultMetamodel;
+import io.github.nextentity.core.meta.impl.TestEntities;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 移植自 feature/embedded-support-d：SQL 构建器对 {@code @Embedded} 属性的 INSERT/UPDATE SQL 生成测试。
+ */
+@DisplayName("SQL构建器 - 嵌入属性持久化")
+class EmbeddedPersistSqlTest {
+
+    private DefaultMetamodel metamodel;
+    private DefaultSqlBuilder sqlBuilder;
+
+    @BeforeEach
+    void setUp() {
+        metamodel = DefaultMetamodel.of();
+        sqlBuilder = new DefaultSqlBuilder(new MySqlDialect(), JdbcConfig.DEFAULT);
+    }
+
+    @Nested
+    @DisplayName("INSERT SQL")
+    class InsertSqlTests {
+
+        @Test
+        @DisplayName("INSERT 包含嵌入属性的子列")
+        void shouldInsertIncludeEmbeddedSubColumns() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+            TestEntities.EntityWithEmbedded entity = new TestEntities.EntityWithEmbedded();
+            entity.setId(1L);
+            entity.setName("John");
+            TestEntities.Address addr = new TestEntities.Address();
+            addr.setStreet("5th Ave");
+            addr.setCity("NYC");
+            addr.setZipCode("10001");
+            entity.setAddress(addr);
+
+            List<InsertSqlStatement> statements = sqlBuilder.buildInsertStatement(
+                    Collections.singletonList(entity), entityType);
+
+            assertThat(statements).hasSize(1);
+            String sql = statements.get(0).sql();
+            assertThat(sql).containsIgnoringCase("city");
+            assertThat(sql).containsIgnoringCase("street");
+            assertThat(sql).containsIgnoringCase("zip_code");
+        }
+
+        @Test
+        @DisplayName("@AttributeOverride 的列名在 INSERT 中正确")
+        void shouldInsertRespectAttributeOverrideColumnName() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverride.class);
+            TestEntities.EntityWithAttributeOverride entity = new TestEntities.EntityWithAttributeOverride();
+            entity.setId(1L);
+            TestEntities.FullName name = new TestEntities.FullName();
+            name.setFirstName("John");
+            name.setLastName("Doe");
+            entity.setFullName(name);
+
+            List<InsertSqlStatement> statements = sqlBuilder.buildInsertStatement(
+                    Collections.singletonList(entity), entityType);
+
+            assertThat(statements).hasSize(1);
+            String sql = statements.get(0).sql();
+            assertThat(sql).containsIgnoringCase("first_name_ov");
+        }
+
+        @Test
+        @DisplayName("INSERT 参数包含嵌入子属性值")
+        void shouldInsertParametersIncludeEmbeddedValues() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+            TestEntities.EntityWithEmbedded entity = new TestEntities.EntityWithEmbedded();
+            entity.setId(1L);
+            entity.setName("John");
+            TestEntities.Address addr = new TestEntities.Address();
+            addr.setStreet("5th Ave");
+            addr.setCity("NYC");
+            addr.setZipCode("10001");
+            entity.setAddress(addr);
+
+            List<InsertSqlStatement> statements = sqlBuilder.buildInsertStatement(
+                    Collections.singletonList(entity), entityType);
+
+            InsertSqlStatement stmt = statements.get(0);
+            ArrayList<Object> firstRow = new ArrayList<>();
+            stmt.parameters().iterator().next().forEach(firstRow::add);
+            // id, name, street, city, zip_code
+            assertThat(firstRow).containsExactly(1L, "John", "5th Ave", "NYC", "10001");
+        }
+    }
+
+    @Nested
+    @DisplayName("UPDATE SQL")
+    class UpdateSqlTests {
+
+        @Test
+        @DisplayName("UPDATE 包含嵌入属性的子列")
+        void shouldUpdateIncludeEmbeddedSubColumns() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithEmbedded.class);
+            TestEntities.EntityWithEmbedded entity = new TestEntities.EntityWithEmbedded();
+            entity.setId(1L);
+            entity.setName("John");
+            TestEntities.Address addr = new TestEntities.Address();
+            addr.setStreet("5th Ave");
+            addr.setCity("NYC");
+            addr.setZipCode("10001");
+            entity.setAddress(addr);
+
+            BatchSqlStatement stmt = sqlBuilder.buildUpdateStatement(
+                    Collections.singletonList(entity), entityType);
+
+            String sql = stmt.sql();
+            assertThat(sql).containsIgnoringCase("street");
+            assertThat(sql).containsIgnoringCase("city");
+            assertThat(sql).containsIgnoringCase("zip_code");
+        }
+
+        @Test
+        @DisplayName("@AttributeOverride 的列名在 UPDATE 中正确")
+        void shouldUpdateRespectAttributeOverrideColumnName() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithAttributeOverride.class);
+            TestEntities.EntityWithAttributeOverride entity = new TestEntities.EntityWithAttributeOverride();
+            entity.setId(1L);
+            entity.setName("John");
+            TestEntities.FullName name = new TestEntities.FullName();
+            name.setFirstName("John");
+            name.setLastName("Doe");
+            entity.setFullName(name);
+
+            BatchSqlStatement stmt = sqlBuilder.buildUpdateStatement(
+                    Collections.singletonList(entity), entityType);
+
+            String sql = stmt.sql();
+            assertThat(sql).containsIgnoringCase("first_name_ov");
+        }
+    }
+
+    @Nested
+    @DisplayName("嵌套嵌入持久化")
+    class NestedEmbeddedPersistTests {
+
+        @Test
+        @DisplayName("INSERT 包含嵌套嵌入的所有子列")
+        void shouldInsertIncludeNestedEmbeddedColumns() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedEmbedded.class);
+            TestEntities.EntityWithNestedEmbedded entity = new TestEntities.EntityWithNestedEmbedded();
+            entity.setId(1L);
+            TestEntities.ContactInfo contact = new TestEntities.ContactInfo();
+            contact.setEmail("a@b.com");
+            contact.setPhone("123456");
+            TestEntities.Address addr = new TestEntities.Address();
+            addr.setStreet("5th Ave");
+            addr.setCity("NYC");
+            addr.setZipCode("10001");
+            contact.setAddress(addr);
+            entity.setContactInfo(contact);
+
+            List<InsertSqlStatement> statements = sqlBuilder.buildInsertStatement(
+                    Collections.singletonList(entity), entityType);
+
+            assertThat(statements).hasSize(1);
+            String sql = statements.get(0).sql();
+            assertThat(sql).containsIgnoringCase("email");
+            assertThat(sql).containsIgnoringCase("phone");
+            assertThat(sql).containsIgnoringCase("street");
+            assertThat(sql).containsIgnoringCase("city");
+            assertThat(sql).containsIgnoringCase("zip_code");
+        }
+
+        @Test
+        @DisplayName("嵌套 @AttributeOverride 的列名在 INSERT 中正确")
+        void shouldInsertRespectNestedAttributeOverride() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedAttributeOverride.class);
+            TestEntities.EntityWithNestedAttributeOverride entity = new TestEntities.EntityWithNestedAttributeOverride();
+            entity.setId(1L);
+            TestEntities.ContactInfo contact = new TestEntities.ContactInfo();
+            contact.setEmail("a@b.com");
+            contact.setPhone("123456");
+            TestEntities.Address addr = new TestEntities.Address();
+            addr.setStreet("5th Ave");
+            addr.setCity("NYC");
+            addr.setZipCode("10001");
+            contact.setAddress(addr);
+            entity.setContactInfo(contact);
+
+            List<InsertSqlStatement> statements = sqlBuilder.buildInsertStatement(
+                    Collections.singletonList(entity), entityType);
+
+            assertThat(statements).hasSize(1);
+            String sql = statements.get(0).sql();
+            // email 被 @AttributeOverride 为 contact_email
+            assertThat(sql).containsIgnoringCase("contact_email");
+            // address.street 被 @AttributeOverride 为 deep_street
+            assertThat(sql).containsIgnoringCase("deep_street");
+        }
+
+        @Test
+        @DisplayName("UPDATE 包含嵌套嵌入的所有子列")
+        void shouldUpdateIncludeNestedEmbeddedColumns() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithNestedEmbedded.class);
+            TestEntities.EntityWithNestedEmbedded entity = new TestEntities.EntityWithNestedEmbedded();
+            entity.setId(1L);
+            TestEntities.ContactInfo contact = new TestEntities.ContactInfo();
+            contact.setEmail("a@b.com");
+            contact.setPhone("123456");
+            TestEntities.Address addr = new TestEntities.Address();
+            addr.setStreet("5th Ave");
+            addr.setCity("NYC");
+            addr.setZipCode("10001");
+            contact.setAddress(addr);
+            entity.setContactInfo(contact);
+
+            BatchSqlStatement stmt = sqlBuilder.buildUpdateStatement(
+                    Collections.singletonList(entity), entityType);
+
+            String sql = stmt.sql();
+            assertThat(sql).containsIgnoringCase("email");
+            assertThat(sql).containsIgnoringCase("phone");
+            assertThat(sql).containsIgnoringCase("street");
+            assertThat(sql).containsIgnoringCase("city");
+            assertThat(sql).containsIgnoringCase("zip_code");
+        }
+    }
+
+    @Nested
+    @DisplayName("错层嵌套持久化")
+    class CrossLayerPersistTests {
+
+        @Test
+        @DisplayName("INSERT 包含错层嵌套的所有子列")
+        void shouldInsertIncludeCrossLayerColumns() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithCrossLayerEmbedded.class);
+            TestEntities.EntityWithCrossLayerEmbedded entity = new TestEntities.EntityWithCrossLayerEmbedded();
+            entity.setId(1L);
+            TestEntities.AddressWithZip addr = new TestEntities.AddressWithZip();
+            addr.setCity("NYC");
+            TestEntities.ZipCode zip = new TestEntities.ZipCode();
+            zip.setCode("10001");
+            addr.setZip(zip);
+            entity.setAddress(addr);
+            TestEntities.ZipCode secZip = new TestEntities.ZipCode();
+            secZip.setCode("90210");
+            entity.setSecondaryZip(secZip);
+
+            List<InsertSqlStatement> statements = sqlBuilder.buildInsertStatement(
+                    Collections.singletonList(entity), entityType);
+
+            assertThat(statements).hasSize(1);
+            String sql = statements.get(0).sql();
+            assertThat(sql).containsIgnoringCase("city");
+            // code 列会出现两次（address.zip.code 和 secondaryZip.code）
+            long codeCount = countOccurrences(sql, "code");
+            assertThat(codeCount).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("错层 @AttributeOverride 的列名在 INSERT 中正确且独立")
+        void shouldInsertRespectCrossLayerOverride() {
+            EntityType entityType = metamodel.getEntity(TestEntities.EntityWithCrossLayerOverride.class);
+            TestEntities.EntityWithCrossLayerOverride entity = new TestEntities.EntityWithCrossLayerOverride();
+            entity.setId(1L);
+            TestEntities.AddressWithZip addr = new TestEntities.AddressWithZip();
+            addr.setCity("NYC");
+            TestEntities.ZipCode zip = new TestEntities.ZipCode();
+            zip.setCode("10001");
+            addr.setZip(zip);
+            entity.setAddress(addr);
+            TestEntities.ZipCode secZip = new TestEntities.ZipCode();
+            secZip.setCode("90210");
+            entity.setSecondaryZip(secZip);
+
+            List<InsertSqlStatement> statements = sqlBuilder.buildInsertStatement(
+                    Collections.singletonList(entity), entityType);
+
+            assertThat(statements).hasSize(1);
+            String sql = statements.get(0).sql();
+            assertThat(sql).containsIgnoringCase("addr_city");
+            assertThat(sql).containsIgnoringCase("addr_zip_code");
+            assertThat(sql).containsIgnoringCase("sec_zip_code");
+        }
+
+        private long countOccurrences(String sql, String columnName) {
+            String quoted = detectQuote(sql) + columnName + detectQuote(sql);
+            return Pattern.compile(Pattern.quote(quoted), Pattern.CASE_INSENSITIVE)
+                    .matcher(sql).results().count();
+        }
+
+        private String detectQuote(String sql) {
+            if (sql.contains("`")) return "`";
+            if (sql.contains("\"")) return "\"";
+            if (sql.contains("[")) return "[";
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
## 摘要

- 在元模型中添加 `@Embedded` 嵌入属性支持，支持嵌入属性的递归展开
- 支持 `@AttributeOverride`/`@AttributeOverrides` 解析与多层嵌套覆盖
- 修复 `@Embedded` 属性 CRUD 与查询中的路径导航问题（`MetamodelAttribute.getFromRoot()` 沿声明链递归导航）
- 嵌入属性在 SQL 构建中使用主表别名而非 JOIN 别名，避免生成无效 JOIN
- 修复中间嵌入节点为 null 时的导航缺陷

## 变更范围

- **元模型层**：`MetamodelSchema.isEmbedded()`、`MetamodelAttribute.getFromRoot()`、`JoinAttribute.schema()`
- **构造器**：`EntityConstructorBuilder` 强制构造嵌入子属性，不受 fetch 路径限制
- **SQL 构建**：`AbstractStatementBuilder` 跳过嵌入属性的 JOIN，使用主表别名
- **JPA**：`JpaPersistExecutor` 使用 `getFromRoot()` 和路径名处理 JPQL 更新